### PR TITLE
Implemented new approach to find SDK

### DIFF
--- a/cmake/Arduino-Toolchain.cmake
+++ b/cmake/Arduino-Toolchain.cmake
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_LIST_DIR}/Platform/Other/FindArduinoSDK.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/Platform/Other/ArduinoSDKSeeker.cmake)
 
 function(_find_required_programs)
 

--- a/cmake/Platform/Other/ArduinoSDKSeeker.cmake
+++ b/cmake/Platform/Other/ArduinoSDKSeeker.cmake
@@ -1,3 +1,10 @@
+#=============================================================================#
+# Attempts to find the Arduino SDK in the host system, searching at known locations.
+# For each host OS the locations are different, however, eventually they all search for the
+# 'lib/version.txt' file, which is located directly under the SDK directory under ALL OSs.
+#       _return_var - Name of variable in parent-scope holding the return value.
+#       Returns - Path to the found Arudino SDK.
+#=============================================================================#
 function(find_arduino_sdk _return_var)
 
     if (${CMAKE_HOST_UNIX})
@@ -12,20 +19,19 @@ function(find_arduino_sdk _return_var)
         set(platform_search_paths "C:/Program Files (x86)/Arduino" "C:/Program Files/Arduino")
     endif ()
 
-    find_program(arduino_program_path
-            NAMES arduino
+    find_path(ARDUINO_SDK_PATH
+            NAMES lib/version.txt
             HINTS ${platform_search_paths}
             NO_DEFAULT_PATH
             NO_CMAKE_FIND_ROOT_PATH)
-    get_filename_component(sdk_path "${arduino_program_path}" DIRECTORY)
 
-    if (NOT sdk_path OR "${sdk_path}" MATCHES "NOTFOUND")
+    if (${ARDUINO_SDK_PATH} MATCHES "NOTFOUND")
         string(CONCAT error_message
                 "Couldn't find Arduino SDK path - Is it in a non-standard location?" "\n"
                 "If so, please set the ARDUINO_SDK_PATH CMake-Variable")
         message(FATAL_ERROR ${error_message})
     else ()
-        set(${_return_var} "${sdk_path}" PARENT_SCOPE)
+        set(${_return_var} "${ARDUINO_SDK_PATH}" PARENT_SCOPE)
     endif ()
 
 endfunction()


### PR DESCRIPTION
Modified SDK-Finding process to find SDK's version file, **lib/version.txt**, instead of the **arduino** program searched before.
The problem with the older approach was that the **arduino** program resides under different directories on different OSs, which created sort of a chaos.

Closes #16 