### PR TITLE
Added support for Arduino IDE's Sketchbook

### DIFF
--- a/cmake/Platform/Sources/SourceSeeker.cmake
+++ b/cmake/Platform/Sources/SourceSeeker.cmake
@@ -26,6 +26,21 @@ function(_find_sources _base_path _pattern _return_var)
 endfunction()
 
 #=============================================================================#
+# Finds header files matching the pre-defined header-file pattern under the given path.
+# This functions searchs explicitly for header-files such as '*.h'.
+# Search could also be recursive (With sub-directories) if the optional 'RECURSE' option is passed.
+#        _base_path - Top-Directory path to search source files in.
+#        _return_var - Name of variable in parent-scope holding the return value.
+#        Returns - List of header files in the given path
+#=============================================================================#
+function(find_header_files _base_path _return_var)
+
+    _find_sources("${_base_path}" "${ARDUINO_CMAKE_HEADER_FILES_PATTERN}" headers ${ARGN})
+    set(${_return_var} "${headers}" PARENT_SCOPE)
+
+endfunction()
+
+#=============================================================================#
 # Finds source files matching the pre-defined source-file pattern under the given path.
 # This functions searchs explicitly for source-files such as '*.c'.
 # Search could also be recursive (With sub-directories) if the optional 'RECURSE' option is passed.
@@ -41,17 +56,32 @@ function(find_source_files _base_path _return_var)
 endfunction()
 
 #=============================================================================#
-# Finds header files matching the pre-defined header-file pattern under the given path.
-# This functions searchs explicitly for header-files such as '*.h'.
-# Search could also be recursive (With sub-directories) if the optional 'RECURSE' option is passed.
+# Recursively finds header files under the given path, excluding those that don't belong to a library,
+# such as files under the 'exmaples' directory (In case sources reside under lib's root directory).
 #        _base_path - Top-Directory path to search source files in.
 #        _return_var - Name of variable in parent-scope holding the return value.
-#        Returns - List of header files in the given path
+#        Returns - List of source files in the given path
 #=============================================================================#
-function(find_header_files _base_path _return_var)
+function(find_library_header_files _base_path _return_var)
 
-    _find_sources("${_base_path}" "${ARDUINO_CMAKE_HEADER_FILES_PATTERN}" headers ${ARGN})
+    find_header_files(${_base_path} headers RECURSE) # Library headers are always searched recursively
+    list(FILTER headers EXCLUDE REGEX "${ARDUINO_CMAKE_EXCLUDED_LIBRARY_SOURCES_PATTERN}")
     set(${_return_var} "${headers}" PARENT_SCOPE)
+
+endfunction()
+
+#=============================================================================#
+# Recursively finds source files under the given path, excluding those that don't belong to a library,
+# such as files under the 'exmaples' directory (In case sources reside under lib's root directory).
+#        _base_path - Top-Directory path to search source files in.
+#        _return_var - Name of variable in parent-scope holding the return value.
+#        Returns - List of source files in the given path
+#=============================================================================#
+function(find_library_source_files _base_path _return_var)
+
+    find_source_files(${_base_path} sources RECURSE) # Library sources are always searched recursively
+    list(FILTER sources EXCLUDE REGEX "${ARDUINO_CMAKE_EXCLUDED_LIBRARY_SOURCES_PATTERN}")
+    set(${_return_var} "${sources}" PARENT_SCOPE)
 
 endfunction()
 

--- a/cmake/Platform/System/BuildSystemInitializer.cmake
+++ b/cmake/Platform/System/BuildSystemInitializer.cmake
@@ -2,6 +2,7 @@ include(AvrToolsFinder)
 include(VersionDetector)
 include(PlatformInitializer)
 include(LinuxDistDetector)
+include(SketchbookFinder)
 
 function(find_required_platform_tools)
 
@@ -22,6 +23,9 @@ function(initialize_build_system)
     detect_sdk_version()
     if (CMAKE_HOST_UNIX AND NOT CMAKE_HOST_APPLE) # Detect host's Linux distribution
         detect_host_linux_distribution()
+    endif ()
+    if (AUTO_SET_SKETCHBOOK_PATH)
+        find_sketchbook_path()
     endif ()
 
     initialize_arduino_platform()

--- a/cmake/Platform/System/DefaultsManager.cmake
+++ b/cmake/Platform/System/DefaultsManager.cmake
@@ -30,6 +30,9 @@ function(set_source_files_patterns)
             "Header Files Pattern")
     set(ARDUINO_CMAKE_SKETCH_FILES_PATTERN *.ino *.pde CACHE STRING
             "Sketch Files Pattern")
+    set(ARDUINO_CMAKE_EXCLUDED_LIBRARY_SOURCES_PATTERN "examples?/.+" CACHE STRING
+            "Regex pattern matching all sources that should be excluded from search
+             when dealing with libraries")
 
 endfunction()
 

--- a/cmake/Platform/System/DefaultsManager.cmake
+++ b/cmake/Platform/System/DefaultsManager.cmake
@@ -39,15 +39,21 @@ endfunction()
 function(set_default_arduino_cmake_options)
 
     option(USE_DEFAULT_PLATFORM_IF_NONE_EXISTING
-            "Whether to use Arduino as default platform if none is supplied" ON)
+            "Whether to use Arduino as default platform if none is supplied"
+            ON)
     option(USE_CUSTOM_PLATFORM_HEADER
             "Whether to expect and use a custom-supplied platform header, \
-            skipping the selection algorithm" OFF)
+            skipping the selection algorithm"
+            OFF)
     option(USE_ARCHLINUX_BUILTIN_SUPPORT
-            "Whether to use Arduino CMake's built-in support for the archlinux distribution" ON)
+            "Whether to use Arduino CMake's built-in support for the archlinux distribution"
+            ON)
     option(CONVERT_SKETCHES_IF_CONVERTED_SOURCES_EXISTS
             "Whether to convert sketches to source files even if converted sources already exist"
             OFF)
+    option(AUTO_SET_SKETCHBOOK_PATH
+            "Whether Arduino IDE's Sketchbook Location should be automatically found"
+            ON)
 
 endfunction()
 

--- a/cmake/Platform/System/DefaultsManager.cmake
+++ b/cmake/Platform/System/DefaultsManager.cmake
@@ -56,7 +56,7 @@ function(set_default_arduino_cmake_options)
             OFF)
     option(AUTO_SET_SKETCHBOOK_PATH
             "Whether Arduino IDE's Sketchbook Location should be automatically found"
-            ON)
+            OFF)
 
 endfunction()
 

--- a/cmake/Platform/System/SketchbookFinder.cmake
+++ b/cmake/Platform/System/SketchbookFinder.cmake
@@ -1,0 +1,51 @@
+#=============================================================================#
+# Gets the path of the user's Arduino IDE preferences file, usually located in a hidden directory
+# under the home directory.
+#       _return_var - Name of variable in parent-scope holding the return value.
+#       Returns - Filtered list of architectures.
+#=============================================================================#
+function(_get_user_preferences_file_path _return_var)
+
+    set(preferences_file_name preferences.txt)
+
+    if (${CMAKE_HOST_UNIX})
+        if (${CMAKE_HOST_APPLE}) # Mac OS X
+            set(dir_path "$ENV{HOME}/Library/Processing/${preferences_file_name}")
+        else () # Linux
+            set(dir_path "$ENV{HOME}/.processing/${preferences_file_name}")
+        endif ()
+    else () # Windows
+        string(REPLACE "\\" "/" home_path $ENV{HOMEPATH})
+        string(REPLACE "\\" "/" home_drive $ENV{HOMEDRIVE})
+        string(CONCAT home_path ${home_drive} ${home_path})
+        set(dir_path "${home_path}/AppData/Local/arduino15/${preferences_file_name}")
+    endif ()
+
+    set(${_return_var} ${dir_path} PARENT_SCOPE)
+
+endfunction()
+
+#=============================================================================#
+# Finds the location of Arduino IDE's Sketchbook directory, where all libraries and sketches
+# are downloaded to.
+#=============================================================================#
+function(find_sketchbook_path)
+
+    _get_user_preferences_file_path(arduino_ide_preferences_file)
+    if (NOT EXISTS "${arduino_ide_preferences_file}")
+        string(CONCAT error_message
+                "Arduino IDE preferences file couldn't be found at "
+                "${arduino_ide_preferences_file}.\n"
+                "ARDUINO_CMAKE_SKETCHBOOK_PATH should be manually set to the real Sketchbook path")
+        message(WARNING ${error_message})
+        return()
+    endif ()
+
+    file(STRINGS "${arduino_ide_preferences_file}" arduino_ide_preferences)
+    list(FILTER arduino_ide_preferences INCLUDE REGEX "sketchbook")
+    _get_property_value(${arduino_ide_preferences} sketchbook_path)
+
+    set(ARDUINO_CMAKE_SKETCHBOOK_PATH "${sketchbook_path}" CACHE PATH
+            "Arduino IDE's Sketchbook Path")
+
+endfunction()

--- a/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
+++ b/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
@@ -102,13 +102,18 @@ function(find_arduino_library _target_name _library_name _board_id)
     if (NOT find_lib_3RD_PARTY)
         convert_string_to_pascal_case(${_library_name} _library_name)
     endif ()
-    set(library_path "${ARDUINO_SDK_LIBRARIES_PATH}/${_library_name}")
-    set(library_properties_path "${library_path}/library.properties")
 
-    if (NOT EXISTS "${library_properties_path}")
+    find_file(library_properties_file library.properties
+            PATHS ${ARDUINO_SDK_LIBRARIES_PATH} ${ARDUINO_CMAKE_SKETCHBOOK_PATH}/libraries
+            PATH_SUFFIXES ${_library_name}
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH)
+
+    if (${library_properties_file} MATCHES "NOTFOUND")
         message(SEND_ERROR "Couldn't find library named ${_library_name}")
     else () # Library is found
-        _get_library_architecture("${library_properties_path}" lib_arch)
+        get_filename_component(library_path ${library_properties_file} DIRECTORY)
+        _get_library_architecture("${library_properties_file}" lib_arch)
         if (lib_arch)
             if ("${lib_arch}" MATCHES "UNSUPPORTED")
                 string(CONCAT error_message
@@ -139,6 +144,8 @@ function(find_arduino_library _target_name _library_name _board_id)
             endif ()
         endif ()
     endif ()
+
+    unset(library_properties_file CACHE)
 
 endfunction()
 

--- a/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
+++ b/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
@@ -124,19 +124,14 @@ function(find_arduino_library _target_name _library_name _board_id)
             endif ()
         endif ()
 
-        find_header_files("${library_path}/src" library_headers RECURSE)
-
+        find_library_header_files("${library_path}" library_headers)
         if (NOT library_headers)
-            set(error_message
-                    "${_library_name} doesn't have any header files under the 'src' directory")
+            set(error_message "Couldn't find any header files for the ${_library_name} library")
             message(SEND_ERROR "${error_message}")
         else ()
-            find_source_files("${library_path}/src" library_sources RECURSE)
-
+            find_library_source_files("${library_path}" library_sources)
             if (NOT library_sources)
-                set(error_message
-                        "${_library_name} doesn't have any source files \
-                         under the 'src' directory")
+                set(error_message "Couldn't find any source files for the ${_library_name} library")
                 message(SEND_ERROR "${error_message}")
             else ()
                 set(sources ${library_headers} ${library_sources})


### PR DESCRIPTION
Arduino IDE's *Sketchbook* can now be used as an additional search path for libraries, especially 3rd party.

By default, the *Sketchbook* isn't automatically located, and to use it one should manually set the `ARDUINO_CMAKE_SKETCHBOOK_PATH` variable. However, this behavior can be changed by enabling the `AUTO_SET_SKETCHBOOK_PATH` option.

**Note:** *Sketchbook Location* is only valid after the **Arduino IDE** itself has run at least once, otherwise it won't create a `preferences` file which specifies *Sketchbook*'s location.

Fixes #15 