### PR TITLE
Inform user of missing dependencies instead

### DIFF
--- a/cmake/Platform/System/LinuxDistDetector.cmake
+++ b/cmake/Platform/System/LinuxDistDetector.cmake
@@ -6,6 +6,11 @@ function(detect_host_linux_distribution)
         message(AUTHOR_WARNING "Linux distribution detection called on Apple platform")
     else () # Linux host
         find_program(lsb_release_exec lsb_release)
+
+        if ("lsb_release_exec-NOTFOUND" STREQUAL "${lsb_release_exec}")
+            message(FATAL_ERROR "`lsb_release' not found")
+        endif()
+        
         execute_process(COMMAND ${lsb_release_exec} -is
                 OUTPUT_VARIABLE lsb_release_id_short
                 OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Instead of failing with a cryptic error message like

```
CMake Error at /tmp/Arduino-CMake-NG/cmake/Platform/System/LinuxDistDetector.cmake:12 (string):
  string no output variable specified
Call Stack (most recent call first):
  /tmp/Arduino-CMake-NG/cmake/Platform/System/BuildSystemInitializer.cmake:25 (detect_host_linux_distribution)
  /tmp/Arduino-CMake-NG/cmake/Platform/Arduino.cmake:34 (initialize_build_system)
  /usr/share/cmake-3.10/Modules/CMakeSystemSpecificInformation.cmake:26 (include)
  CMakeLists.txt:2 (project)
```

let's fail with a clean message about missing dependencies :-)