### PR TITLE
Added support for libraries that don't have a properties file

### DIFF
--- a/cmake/Platform/Libraries/LibrariesFinder.cmake
+++ b/cmake/Platform/Libraries/LibrariesFinder.cmake
@@ -17,17 +17,17 @@ function(find_arduino_library _target_name _library_name _board_id)
         convert_string_to_pascal_case(${_library_name} _library_name)
     endif ()
 
-    find_file(library_properties_file library.properties
-            PATHS ${ARDUINO_SDK_LIBRARIES_PATH} ${ARDUINO_CMAKE_SKETCHBOOK_PATH}/libraries
-            PATH_SUFFIXES ${_library_name}
+    find_file(library_path
+            NAMES ${_library_name}
+            PATHS ${ARDUINO_SDK_LIBRARIES_PATH} ${ARDUINO_CMAKE_SKETCHBOOK_PATH}
+            PATH_SUFFIXES libraries
             NO_DEFAULT_PATH
             NO_CMAKE_FIND_ROOT_PATH)
 
     if (${library_properties_file} MATCHES "NOTFOUND")
         message(SEND_ERROR "Couldn't find library named ${_library_name}")
-    else () # Library is found
 
-        get_filename_component(library_path ${library_properties_file} DIRECTORY)
+    else () # Library is found
 
         find_library_header_files("${library_path}" library_headers)
 
@@ -50,15 +50,13 @@ function(find_arduino_library _target_name _library_name _board_id)
                 else ()
                     set(sources ${library_headers} ${library_sources})
 
-                    add_arduino_library(${_target_name} ${_board_id}
-                            LIB_PROPS_FILE ${library_properties_file}
-                            ${sources})
+                    add_arduino_library(${_target_name} ${_board_id} ${sources})
                 endif ()
 
             endif ()
         endif ()
     endif ()
 
-    unset(library_properties_file CACHE)
+    unset(library_path CACHE)
 
 endfunction()

--- a/cmake/Platform/Libraries/LibrariesFinder.cmake
+++ b/cmake/Platform/Libraries/LibrariesFinder.cmake
@@ -21,7 +21,8 @@ function(find_arduino_library _target_name _library_name _board_id)
     find_file(library_path
             NAMES ${_library_name}
             PATHS ${ARDUINO_SDK_LIBRARIES_PATH} ${ARDUINO_CMAKE_SKETCHBOOK_PATH}
-            PATH_SUFFIXES libraries
+            ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}
+            PATH_SUFFIXES libraries dependencies
             NO_DEFAULT_PATH
             NO_CMAKE_FIND_ROOT_PATH)
 
@@ -34,6 +35,7 @@ function(find_arduino_library _target_name _library_name _board_id)
 
         if (NOT library_headers)
             message(SEND_ERROR "Couldn't find any header files for the ${_library_name} library")
+
         else ()
 
             if (parsed_args_HEADER_ONLY)
@@ -48,14 +50,19 @@ function(find_arduino_library _target_name _library_name _board_id)
                             "${_library_name} library - Is it a header-only library?"
                             "If so, please pass the HEADER_ONLY option "
                             "as an argument to the function")
+
                 else ()
+
                     set(sources ${library_headers} ${library_sources})
 
                     add_arduino_library(${_target_name} ${_board_id} ${sources})
+
                 endif ()
 
             endif ()
+
         endif ()
+
     endif ()
 
     unset(library_path CACHE)

--- a/cmake/Platform/Libraries/LibrariesFinder.cmake
+++ b/cmake/Platform/Libraries/LibrariesFinder.cmake
@@ -7,6 +7,7 @@
 #       _library_name - Name of the Arduino library to find.
 #       _board_id - Board ID associated with the linked Core Lib.
 #       [3RD_PARTY] - Whether library should be treated as a 3rd Party library.
+#       [HEADER_ONLY] - Whether library should be treated as header-only library.
 #=============================================================================#
 function(find_arduino_library _target_name _library_name _board_id)
 

--- a/cmake/Platform/Libraries/LibrarySourcesArchitectureResolver.cmake
+++ b/cmake/Platform/Libraries/LibrarySourcesArchitectureResolver.cmake
@@ -38,9 +38,8 @@ function(resolve_library_architecture _library_sources _return_var)
     else ()
 
         # Warn user and assume library is arch-agnostic
-        message(STATUS "Library's properties file can't be found "
-                "under its' root directory - Assuming the library "
-                "is architecture-agnostic (supports all architectures)")
+        message(STATUS "Library's properties file can't be found under its' root directory.\n\t"
+                "Assuming the library is architecture-agnostic (supports all architectures)")
         set(${_return_var} "${_library_sources}" PARENT_SCOPE)
         return()
 

--- a/cmake/Platform/Sources/ArduinoLibrarySourcesSeeker.cmake
+++ b/cmake/Platform/Sources/ArduinoLibrarySourcesSeeker.cmake
@@ -8,10 +8,18 @@
 function(find_library_header_files _base_path _return_var)
 
     if (EXISTS ${_base_path}/src) # 'src' sub-dir exists and should contain sources
+
         # Headers are always searched recursively under the 'src' sub-dir
         find_header_files(${_base_path}/src headers RECURSE)
+
     else ()
-        find_header_files(${_base_path} headers)
+
+        # Both root-dir and 'utility' sub-dir are searched when 'src' doesn't exist
+        find_header_files(${_base_path} root_headers)
+        find_header_files(${_base_path}/utility utility_headers)
+
+        set(headers ${root_headers} ${utility_headers})
+
     endif ()
 
     set(${_return_var} "${headers}" PARENT_SCOPE)
@@ -28,10 +36,18 @@ endfunction()
 function(find_library_source_files _base_path _return_var)
 
     if (EXISTS ${_base_path}/src)
+
         # Sources are always searched recursively under the 'src' sub-dir
         find_source_files(${_base_path}/src sources RECURSE)
+
     else ()
-        find_source_files(${_base_path} sources)
+
+        # Both root-dir and 'utility' sub-dir are searched when 'src' doesn't exist
+        find_source_files(${_base_path} root_sources)
+        find_source_files(${_base_path}/utility utility_sources)
+
+        set(sources ${root_sources} ${utility_sources})
+
     endif ()
 
     set(${_return_var} "${sources}" PARENT_SCOPE)

--- a/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
+++ b/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
@@ -3,31 +3,22 @@
 # As it's an Arduino library, it also finds and links all dependent platform libraries (if any).
 #       _target_name - Name of the library target to be created. Usually library's real name.
 #       _board_id - Board ID associated with the linked Core Lib.
-#       [LIB_PROPS_FILE] - Full path to the library's properties file. Optional.
 #       [Sources] - List of source files (Could also be headers for code-inspection in some IDEs)
 #                   to create the executable from, similar to CMake's built-in add_executable.
 #=============================================================================#
 function(add_arduino_library _target_name _board_id)
 
-    cmake_parse_arguments(parsed_args "" "LIB_PROPS_FILE" "" ${ARGN})
-    parse_sources_arguments(parsed_sources "" "LIB_PROPS_FILE" "" "${ARGN}")
+    parse_sources_arguments(parsed_sources "" "" "" "${ARGN}")
 
-    if (parsed_args_LIB_PROPS_FILE)
+    get_sources_root_directory("${parsed_sources}" library_root_dir)
+
+    get_library_properties_file(${library_root_dir} library_properties_file)
+
+    if (library_properties_file) # Properties file has been found
         resolve_library_architecture("${parsed_sources}" arch_resolved_sources
-                LIB_PROPS_FILE ${parsed_args_LIB_PROPS_FILE})
+                LIB_PROPS_FILE ${library_properties_file})
     else ()
-
-        get_sources_root_directory("${parsed_sources}" library_root_dir)
-
-        get_library_properties_file(${library_root_dir} library_properties_file)
-
-        if (library_properties_file) # Properties file has been found
-            resolve_library_architecture("${parsed_sources}" arch_resolved_sources
-                    LIB_PROPS_FILE ${library_properties_file})
-        else ()
-            resolve_library_architecture("${parsed_sources}" arch_resolved_sources)
-        endif ()
-
+        resolve_library_architecture("${parsed_sources}" arch_resolved_sources)
     endif ()
 
     _add_arduino_cmake_library(${_target_name} ${_board_id} "${arch_resolved_sources}")

--- a/cmake/Platform/Utilities/LibraryUtils.cmake
+++ b/cmake/Platform/Utilities/LibraryUtils.cmake
@@ -19,7 +19,7 @@ function(get_library_properties_file _library_root_directory _return_var)
     set(lib_props_file ${absolute_lib_root_dir}/${ARDUINO_CMAKE_LIBRARY_PROPERTIES_FILE_NAME})
 
     if (NOT EXISTS ${lib_props_file})
-        message(WARNING "Library's properties file doesn't exist under the given root directory.\n"
+        message(STATUS "Library's properties file doesn't exist under the given root directory.\n\t"
                 "Root directory: ${absolute_lib_root_dir}")
         return()
     endif ()

--- a/examples/3rd-party-library/CMakeLists.txt
+++ b/examples/3rd-party-library/CMakeLists.txt
@@ -17,9 +17,13 @@ target_include_directories(Adafruit_NeoPixel PUBLIC libraries/Adafruit_NeoPixel)
 set(ARDUINO_CMAKE_SKETCHBOOK_PATH "${CMAKE_CURRENT_LIST_DIR}")
 find_arduino_library(Adafruit_GFX Adafruit-GFX-Library ${board_id} 3RD_PARTY)
 # We can also explicitly add additional directories to the target,
-# as only root dir and 'src' sub-dir are added by default
+# as only root dir and 'src' and 'utility' sub-dirs are added by default
 target_source_directories(Adafruit_GFX DIRS libraries/Adafruit-GFX-Library/Fonts)
+
+# We can even automatically find a library that doesn't have a properties file!
+find_arduino_library(sky_writer Skywriter ${board_id} 3RD_PARTY)
 
 # Link all libraries to our previously created target
 link_arduino_library(3rd_Party_Arduino_Library Adafruit_NeoPixel ${board_id})
 link_arduino_library(3rd_Party_Arduino_Library Adafruit_GFX ${board_id})
+link_arduino_library(3rd_Party_Arduino_Library sky_writer ${board_id})

--- a/examples/3rd-party-library/CMakeLists.txt
+++ b/examples/3rd-party-library/CMakeLists.txt
@@ -9,21 +9,21 @@ add_arduino_executable(3rd_Party_Arduino_Library ${board_id} 3rd_party.cpp
 target_include_directories(3rd_Party_Arduino_Library PRIVATE include)
 
 # Add the "NeoPixel" library manually using the library addition API
-add_arduino_library(Adafruit_NeoPixel ${board_id} libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.cpp)
-target_include_directories(Adafruit_NeoPixel PUBLIC libraries/Adafruit_NeoPixel)
+add_arduino_library(adafruit_NeoPixel ${board_id} libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.cpp)
+target_include_directories(adafruit_NeoPixel PUBLIC libraries/Adafruit_NeoPixel)
 
 # Find the "GFX" library by 'tricking' the framework to use current directory as the Sketchbook path,
 # allowing us to use the 'find' API
 set(ARDUINO_CMAKE_SKETCHBOOK_PATH "${CMAKE_CURRENT_LIST_DIR}")
-find_arduino_library(Adafruit_GFX Adafruit-GFX-Library ${board_id} 3RD_PARTY)
+find_arduino_library(adafruit_GFX Adafruit-GFX-Library ${board_id} 3RD_PARTY)
 # We can also explicitly add additional directories to the target,
 # as only root dir and 'src' and 'utility' sub-dirs are added by default
-target_source_directories(Adafruit_GFX DIRS libraries/Adafruit-GFX-Library/Fonts)
+target_source_directories(adafruit_GFX DIRS libraries/Adafruit-GFX-Library/Fonts)
 
 # We can even automatically find a library that doesn't have a properties file!
 find_arduino_library(sky_writer Skywriter ${board_id} 3RD_PARTY)
 
 # Link all libraries to our previously created target
-link_arduino_library(3rd_Party_Arduino_Library Adafruit_NeoPixel ${board_id})
-link_arduino_library(3rd_Party_Arduino_Library Adafruit_GFX ${board_id})
+link_arduino_library(3rd_Party_Arduino_Library adafruit_NeoPixel ${board_id})
+link_arduino_library(3rd_Party_Arduino_Library adafruit_GFX ${board_id})
 link_arduino_library(3rd_Party_Arduino_Library sky_writer ${board_id})

--- a/examples/3rd-party-library/CMakeLists.txt
+++ b/examples/3rd-party-library/CMakeLists.txt
@@ -12,9 +12,7 @@ target_include_directories(3rd_Party_Arduino_Library PRIVATE include)
 add_arduino_library(adafruit_NeoPixel ${board_id} libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.cpp)
 target_include_directories(adafruit_NeoPixel PUBLIC libraries/Adafruit_NeoPixel)
 
-# Find the "GFX" library by 'tricking' the framework to use current directory as the Sketchbook path,
-# allowing us to use the 'find' API
-set(ARDUINO_CMAKE_SKETCHBOOK_PATH "${CMAKE_CURRENT_LIST_DIR}")
+# Find the "GFX" library - It's located under the 'libraries' sub-dir, which is a valid search path
 find_arduino_library(adafruit_GFX Adafruit-GFX-Library ${board_id} 3RD_PARTY)
 # We can also explicitly add additional directories to the target,
 # as only root dir and 'src' and 'utility' sub-dirs are added by default

--- a/examples/3rd-party-library/libraries/Skywriter/examples/NeoPaint/NeoPaint.ino
+++ b/examples/3rd-party-library/libraries/Skywriter/examples/NeoPaint/NeoPaint.ino
@@ -1,0 +1,111 @@
+#include <Adafruit_NeoPixel.h>
+#include <Wire.h>
+
+#define PIN 8
+
+Adafruit_NeoPixel Neopixel = Adafruit_NeoPixel(64, PIN, NEO_GRB + NEO_KHZ800);
+
+unsigned long brightness = 50;
+unsigned char color = 0;
+
+// Include string names of gestures/touches for testing
+//#define SKYWRITER_INC_DEBUG_STRINGS
+#include "skywriter.h"
+
+unsigned int max_x, max_y, max_z;
+unsigned int min_x, min_y, min_z;
+
+void setup() {
+  Serial.begin(9600);
+  while(!Serial){};
+  Serial.println("Hello world!");
+  
+  Neopixel.begin();
+  Neopixel.setBrightness(brightness);
+  Neopixel.show(); // Initialize all pixels to 'off'
+ 
+  
+  Skywriter.begin(12, 13);
+  Skywriter.onTouch(touch);
+  //Skywriter.onAirwheel(airwheel);
+  Skywriter.onGesture(gesture);
+  Skywriter.onXYZ(xyz);
+}
+
+void loop() {
+  Skywriter.poll();
+  /*int x;
+  for(x = 0; x < 64; x++){
+   Neopixel.setPixelColor(x, Wheel(color)); 
+  }*/
+  Neopixel.show();
+}
+
+void xyz(unsigned int x, unsigned int y, unsigned int z){
+  if (x < min_x) min_x = x;
+  if (y < min_y) min_y = y;
+  if (z < min_z) min_z = z;
+  if (x > max_x) max_x = x;
+  if (y > max_y) max_y = y;
+  if (z > max_z) max_z = z;
+  
+  unsigned char pixel_x = map(x, min_x, max_x, 0, 7);
+  unsigned char pixel_y = map(y, min_y, max_y, 0, 7);
+  uint32_t color        = Wheel(map(z, min_z, max_z, 0, 255));
+ 
+  
+  Neopixel.setPixelColor(pixel_x*8 + pixel_y, color);
+  
+  char buf[64];
+  sprintf(buf, "%05u:%05u:%05u gest:%02u touch:%02u", x, y, z, Skywriter.last_gesture, Skywriter.last_touch);
+  Serial.println(buf);
+}
+
+void gesture(unsigned char type){
+  Serial.println("Got gesture ");
+  Serial.print(type,DEC);
+  Serial.print('\n');
+  
+  if( type == SW_FLICK_WEST_EAST ){
+     Neopixel.clear(); 
+  }
+}
+
+void touch(unsigned char type){
+  Serial.println("Got touch ");
+  Serial.print(type,DEC);
+  Serial.print('\n');
+  
+  if( type == SW_TOUCH_CENTER ){
+    Neopixel.setBrightness(map(Skywriter.x, min_x, max_x, 0, 255));
+    //color = map(Skywriter.y, min_y, max_y, 0, 255);
+  }
+  /*else if( type == SW_TOUCH_EAST ){
+     Neopixel.setBrightness(0);
+  }
+  else if( type == SW_TOUCH_WEST ){
+     Neopixel.setBrightness(255);
+  }*/
+}
+
+void airwheel(int delta){
+  Serial.println("Got airwheel ");
+  Serial.print(delta);
+  Serial.print('\n');
+  
+  brightness += (delta/100.0);
+  Neopixel.setBrightness(brightness % 255);
+}
+
+uint32_t Wheel(byte WheelPos) {
+  if(WheelPos < 85) {
+   return Neopixel.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
+  } else if(WheelPos < 170) {
+   WheelPos -= 85;
+   return Neopixel.Color(255 - WheelPos * 3, 0, WheelPos * 3);
+  } else {
+   WheelPos -= 170;
+   return Neopixel.Color(0, WheelPos * 3, 255 - WheelPos * 3);
+  }
+}
+

--- a/examples/3rd-party-library/libraries/Skywriter/examples/SkyPainter/SkyPainter.ino
+++ b/examples/3rd-party-library/libraries/Skywriter/examples/SkyPainter/SkyPainter.ino
@@ -1,0 +1,128 @@
+/*
+ SkyPainter
+ An advanced example showing the SkyWriter board acting as a 3D paint input
+ for a NeoPixel matrix.
+
+ Paint in the air with your finger, X/Y translate as normal, and Z is colour!
+*/
+#include <Adafruit_NeoPixel.h>
+#include <Wire.h>
+#include <skywriter.h>
+
+#define PIN 8          // Pin for NeoPixel matrix
+#define PIN_TRFR  2    // TRFR Pin of Skywriter
+#define PIN_RESET 3    // Reset Pin of Skywriter
+
+Adafruit_NeoPixel Neopixel = Adafruit_NeoPixel(64, PIN, NEO_GRB + NEO_KHZ800);
+
+unsigned long brightness = 50;
+unsigned char color = 0;
+
+long touch_timeout = 0;
+
+/*
+ Keep track of the minimum and maximum X, Y, Z values
+ for on-the-fly calibration of finger-to-led relationship
+*/
+unsigned int max_x, max_y, max_z;
+unsigned int min_x, min_y, min_z;
+
+void setup() {
+  min_x = 255;
+  min_y = 255;
+  min_z = 255;
+  
+  Serial.begin(9600);
+  while(!Serial){};
+  Serial.println("Hello world!");
+  
+  Neopixel.begin();
+  Neopixel.setBrightness(brightness);
+  Neopixel.show();
+  
+  Skywriter.begin(PIN_TRFR, PIN_RESET);
+  Skywriter.onTouch(touch);
+  
+  // Track gestures for clearing the screen
+  Skywriter.onGesture(gesture);
+  Skywriter.onXYZ(xyz);
+}
+
+/*
+ Poll from any updates form Skywriter
+*/
+void loop() {
+  // Poll for any updates from Skywriter
+  // And update the NeoPixel matrix
+  Skywriter.poll();
+  Neopixel.show();
+  if( touch_timeout > 0 ) touch_timeout--;
+}
+
+/*
+ Handle the XYZ updates, determine min/max
+ values and scale them to fit the display
+*/
+void xyz(unsigned int x, unsigned int y, unsigned int z){
+  if( touch_timeout > 0 ) return;
+  
+  if (x < min_x) min_x = x;
+  if (y < min_y) min_y = y;
+  if (z < min_z) min_z = z;
+  if (x > max_x) max_x = x;
+  if (y > max_y) max_y = y;
+  if (z > max_z) max_z = z;
+  
+  unsigned char pixel_x = map(x, min_x, max_x, 0, 7);
+  unsigned char pixel_y = map(y, min_y, max_y, 0, 7);
+  uint32_t color        = Wheel(map(z, min_z, max_z, 0, 255));
+ 
+  Neopixel.setPixelColor(pixel_x*8 + pixel_y, color);
+  
+  char buf[18];
+  sprintf(buf, "%05u:%05u:%05u", x, y, z);
+  Serial.println(buf);
+}
+
+/*
+ Flicking from West to East will clear
+ the Matrix.
+*/
+void gesture(unsigned char type){
+  Serial.println("Got gesture ");
+  Serial.print(type,DEC);
+  Serial.print('\n');
+  
+  if( type == SW_FLICK_WEST_EAST ){
+     Neopixel.clear(); 
+  }
+}
+
+/*
+ Touching the center of Skywriter will switch
+ to brightness control mode. Letting you
+ adjust the brightness of the pixels.
+*/
+void touch(unsigned char type){
+  Serial.println("Got touch ");
+  Serial.print(type,DEC);
+  Serial.print('\n');
+  
+  if( type == SW_TOUCH_CENTER ){
+    touch_timeout = 100;
+    Neopixel.setBrightness(map(Skywriter.x, min_x, max_x, 0, 255));
+  }
+}
+
+uint32_t Wheel(byte WheelPos) {
+  if(WheelPos < 85) {
+   return Neopixel.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
+  } else if(WheelPos < 170) {
+   WheelPos -= 85;
+   return Neopixel.Color(255 - WheelPos * 3, 0, WheelPos * 3);
+  } else {
+   WheelPos -= 170;
+   return Neopixel.Color(0, WheelPos * 3, 255 - WheelPos * 3);
+  }
+}
+

--- a/examples/3rd-party-library/libraries/Skywriter/examples/SkywriterInterrupt/SkywriterInterrupt.ino
+++ b/examples/3rd-party-library/libraries/Skywriter/examples/SkywriterInterrupt/SkywriterInterrupt.ino
@@ -1,0 +1,65 @@
+/*
+Because interrupts vary from device to device, 
+this example might not work out of the box for you.
+
+Read: http://arduino.cc/en/Reference/attachInterrupt
+and adjust the code for your device accordingly.
+
+*/
+#include <Wire.h>
+#include <skywriter.h>
+
+/*
+ Pin 2 is 
+   interrupt 0 on the Uno
+   interrupt 0 on the Mega2560
+   interrupt 1 on the Leonardo
+   just referred to as pin 2 for Due
+*/
+#define PIN_TRFR  2
+#define PIN_RESET 3
+
+void setup() {
+  Serial.begin(9600);
+  while(!Serial){};  
+  
+  Skywriter.begin(PIN_TRFR, PIN_RESET);
+  Skywriter.onTouch(touch);
+  
+  Serial.println("Hello world!");
+  
+  /* Set up the initial interrupt */
+  attachInterrupt(PIN_TRFR,poll,FALLING); // Arduino Due
+  //attachInterrupt(0,poll,FALLING); // Arduino Uno
+  //attachInterrupt(1,poll,FALLING); // Arduino Leonardo
+  
+}
+
+void poll(){
+  /* It doesn't matter how heavy this interrupt
+  handler is. It will *not* fire again until
+  Skywriter has finished processing the new data
+  and we have re-attached the interrupt. */
+  
+  /* Handle the new data */
+  Skywriter.poll();
+  
+  /* Skywriter must twiddle PIN_TRFR to tell
+  the hardware it's processing the new data.
+  Interrupt needs re-attaching afterwards! */
+  attachInterrupt(PIN_TRFR,poll,FALLING); // Arduino Due
+  //attachInterrupt(0,poll,FALLING); // Arduino Uno
+  //attachInterrupt(1,poll,FALLING); // Arduino Leonardo
+}
+
+void loop() {
+  /* Do something in our loop! */
+  Serial.println("I'm alive!");
+  delay(1000);
+}
+
+void touch(unsigned char type){
+  Serial.println("Got touch ");
+  Serial.print(type,DEC);
+  Serial.print('\n');
+}

--- a/examples/3rd-party-library/libraries/Skywriter/keywords.txt
+++ b/examples/3rd-party-library/libraries/Skywriter/keywords.txt
@@ -1,0 +1,12 @@
+Skywriter   KEYWORD1
+begin       KEYWORD2
+poll        KEYWORD2
+onGesture   KEYWORD2
+onTouch     KEYWORD2
+onAirwheel  KEYWORD2
+onXYZ       KEYWORD2
+x           KEYWORD3
+y           KEYWORD3
+z           KEYWORD3
+last_gesture KEYWORD3
+last_touch   KEYWORD3

--- a/examples/3rd-party-library/libraries/Skywriter/skywriter.cpp
+++ b/examples/3rd-party-library/libraries/Skywriter/skywriter.cpp
@@ -1,0 +1,150 @@
+#include "skywriter.h"
+#include <Arduino.h>
+
+void _SkyWriter::begin(unsigned char pin_xfer, unsigned char pin_reset){
+  this->xfer = pin_xfer;
+  this->rst  = pin_reset;
+  this->addr = SW_ADDR;
+  
+  Wire.begin();
+  
+  pinMode(this->xfer, INPUT_PULLUP);
+  pinMode(this->rst,  OUTPUT);
+  digitalWrite(this->rst, LOW);
+  delay(10);
+  digitalWrite(this->rst, HIGH);
+  delay(50);
+}
+
+void _SkyWriter::poll(){
+  if (!digitalRead(this->xfer)){
+    pinMode(this->xfer, OUTPUT);
+    digitalWrite(this->xfer, LOW);
+    
+    Wire.requestFrom(this->addr, (unsigned char)32);
+    
+    unsigned char d_size,d_flags,d_seq,d_ident;
+    
+    if( Wire.available() >= 4 ){
+      d_size  = Wire.read();
+      d_flags = Wire.read();
+      d_seq   = Wire.read();
+      d_ident = Wire.read();
+    }
+    else{
+      return;
+    }
+    
+    this->command_buffer[0] = '\0';
+    
+    unsigned char i = 0;
+    while(Wire.available()){
+      this->command_buffer[i] = Wire.read();
+      i++;
+    }
+    this->command_buffer[i] = '\0';
+  
+    switch(d_ident){
+      case 0x91:
+        this->handle_sensor_data(this->command_buffer);
+        break;
+      case 0x15:
+        // Status info - Unimplemented
+        break;
+      case 0x83:
+        // Firmware data - Unimplemented
+        break;
+    }
+    
+    
+    digitalWrite(this->xfer, HIGH);
+    pinMode(this->xfer, INPUT);
+  }
+}
+
+void _SkyWriter::onTouch(    void (*function)(unsigned char) ){this->handle_touch    = function;}
+void _SkyWriter::onAirwheel( void (*function)(int)           ){this->handle_airwheel = function;}
+void _SkyWriter::onGesture(  void (*function)(unsigned char) ){this->handle_gesture  = function;}
+void _SkyWriter::onXYZ(      void (*function)(unsigned int,unsigned int,unsigned int) ){this->handle_xyz  = function;}
+
+void _SkyWriter::handle_sensor_data(unsigned char* data){
+/*
+  | HEADER | PAYLOAD
+  |        |  DataOutputConfigMask 2 | TimeStamp 1 | SystemInfo 1 | Content |
+  
+  DataOutputConfigMask
+  Bit 0 - DSPStatus
+  Bit 1 - GestureInfo
+  Bit 2 - TouchInfo
+  Bit 3 - AirWheelInfo
+  Bit 4 - XYZ Position
+  Bit 5 - NoisePower
+  Bit 6-7 - Reserved
+  Bit 8-10 - ElectrodeConfiguration
+  Bit 11 - CICData
+  Bit 12 - SDData
+  Bit 13-15 - Reserved
+  
+  SystemInfo
+  Bit 0 - PositionValid, indicates xyz pos data is valid
+  Bit 1 - AirWheelValid, indicates AirWheel is active and AirWheelInfo is vaid
+  Bit 2 - RawDataValid, indicates CICData and SDData fields are valid
+  Bit 3 - NoisePowerValid, indicates NoisePower field is valid
+  Bit 4 - EnvironmentalNoise, indicates that environmental noise has been detected
+  Bit 5 - Clipping, indicates that the ADCs are clipping
+  Bit 6 - Reserved
+  Bit 7 - DSPRunning, indicates the system is currently running
+  DSPStatus - 2 bytes -
+  GestureInfo - 4 bytes
+  TouchInfo - 4 bytes
+  AirWheelInfo - 2 bytes - first byte indicates rotation, ++ = clockwise, 32 = 1 rotation
+  xyzPosition - 6 bytes - 1+2 = x, 3-4 = y, 5-6 = z
+  NoisePower
+  CICData
+  SDData
+*/  
+      
+      if( data[SW_PAYLOAD_HDR_CONFIGMASK] & SW_DATA_XYZ && data[SW_PAYLOAD_HDR_SYSINFO] & SW_SYS_POSITION ){
+        // Valid XYZ position
+        this->x = data[SW_PAYLOAD_X+1] << 8 | data[SW_PAYLOAD_X];
+        this->y = data[SW_PAYLOAD_Y+1] << 8 | data[SW_PAYLOAD_Y];
+        this->z = data[SW_PAYLOAD_Z+1] << 8 | data[SW_PAYLOAD_Z];
+        
+        if( handle_xyz != NULL ) handle_xyz(this->x,this->y,this->z);
+      }
+      
+      if( data[SW_PAYLOAD_HDR_CONFIGMASK] & SW_DATA_GESTURE && data[SW_PAYLOAD_GESTURE] > 0){
+        // Valid gesture
+        this->last_gesture = data[SW_PAYLOAD_GESTURE];
+        if( this->handle_gesture != NULL ) this->handle_gesture(this->last_gesture);
+      }
+      
+      if ( data[SW_PAYLOAD_HDR_CONFIGMASK] & SW_DATA_TOUCH ){
+        // Valid touch
+        uint16_t touch_action = data[SW_PAYLOAD_TOUCH+1] << 8 | data[SW_PAYLOAD_TOUCH];
+        uint16_t comp = 1 << 14;
+        uint8_t x;
+        for(x = 0; x < 16; x++){
+          if( touch_action & comp ){
+            this->last_touch = x;
+            if( this->handle_touch != NULL ) this->handle_touch(this->last_touch);
+            return;
+          }
+          comp = comp >> 1;
+        }
+      }
+      
+      if( data[SW_PAYLOAD_HDR_CONFIGMASK] & SW_DATA_AIRWHEEL && data[SW_PAYLOAD_HDR_SYSINFO] & SW_SYS_AIRWHEEL ){
+        
+        double delta = (data[SW_PAYLOAD_AIRWHEEL] - lastrotation) / 32.0;
+        
+        if( delta != 0 && delta > -0.5 and delta < 0.5 ){
+          if( this->handle_airwheel != NULL ) this->handle_airwheel(delta * 360.0);  
+        }
+        
+        this->rotation += delta * 360.0;
+        this->rotation %= 360;
+        
+        this->lastrotation = data[SW_PAYLOAD_AIRWHEEL];
+      }
+}

--- a/examples/3rd-party-library/libraries/Skywriter/skywriter.h
+++ b/examples/3rd-party-library/libraries/Skywriter/skywriter.h
@@ -1,0 +1,88 @@
+#include <Wire.h>
+
+#ifndef _SKYWRITER_H
+#define _SKYWRITER_H
+
+#define SW_ADDR 0x42
+
+#define SW_HEADER_SIZE   4
+
+#define SW_DATA_DSP      1 //0b0000000000000001
+#define SW_DATA_GESTURE  1 << 1 //0b0000000000000010
+#define SW_DATA_TOUCH    1 << 2 //0b0000000000000100
+#define SW_DATA_AIRWHEEL 1 << 3 //0b0000000000001000
+#define SW_DATA_XYZ      1 << 4 //0b0000000000010000
+
+#define SW_SYSTEM_STATUS 0x15
+#define SW_REQUEST_MSG   0x06
+#define SW_FW_VERSION    0x83
+#define SW_SET_RUNTIME   0xA2
+#define SW_SENSOR_DATA   0x91
+
+#define SW_PAYLOAD_HDR_CONFIGMASK  0 // 2 Bytes
+#define SW_PAYLOAD_HDR_TS          2 // 1 Byte
+#define SW_PAYLOAD_HDR_SYSINFO     3 // 1 Byte
+#define SW_PAYLOAD_DSP_STATUS      4
+#define SW_PAYLOAD_GESTURE         6  // 4 Bytes
+#define SW_PAYLOAD_TOUCH           10 // 4 Bytes
+#define SW_PAYLOAD_AIRWHEEL        14 // 2 Bytes
+#define SW_PAYLOAD_X               16 // 2 bytes
+#define SW_PAYLOAD_Y               18 // 2 bytes
+#define SW_PAYLOAD_Z               20 // 2 bytes
+
+#define SW_SYS_POSITION            1
+#define SW_SYS_AIRWHEEL            1 << 1
+
+/*
+  Constants for identifying tap
+*/
+#define SW_DOUBLETAP_CENTER        0
+#define SW_DOUBLETAP_EAST          1
+#define SW_DOUBLETAP_NORTH         2
+#define SW_DOUBLETAP_WEST          3
+#define SW_DOUBLETAP_SOUTH         4
+#define SW_TAP_CENTER              5
+#define SW_TAP_EAST                6
+#define SW_TAP_NORTH               7
+#define SW_TAP_WEST                8
+#define SW_TAP_SOUTH               9
+#define SW_TOUCH_CENTER            10
+#define SW_TOUCH_EAST              11
+#define SW_TOUCH_NORTH             12
+#define SW_TOUCH_WEST              13
+#define SW_TOUCH_SOUTH             14
+
+#define SW_GESTURE_GARBAGE         1
+#define SW_FLICK_WEST_EAST         2
+#define SW_FLICK_EAST_WEST         3
+#define SW_FLICK_SOUTH_NORTH       4
+#define SW_FLICK_NORTH_SOUTH       5
+#define SW_CIRCLE_CLOCKWISE        6
+#define SW_CIRCLE_CCLOCKWISE       7
+
+class _SkyWriter 
+{
+  public:
+    void begin(unsigned char pin_xfer, unsigned char pin_reset);
+    void poll();
+    void onTouch( void (*)(unsigned char) );
+    void onAirwheel( void (*)(int) );
+    void onGesture( void (*)(unsigned char) );
+    void onXYZ( void (*)(unsigned int, unsigned int, unsigned int) );
+    unsigned char last_gesture, last_touch;
+    unsigned int  x, y, z;
+    int rotation;
+  private:
+    void (*handle_touch)(unsigned char)   = NULL;
+    void (*handle_airwheel)(int)    = NULL;
+    void (*handle_gesture)(unsigned char) = NULL;
+    void (*handle_xyz)(unsigned int, unsigned int, unsigned int);
+    int lastrotation;
+    unsigned char xfer, rst, addr;
+    unsigned char command_buffer[32];
+    void handle_sensor_data(unsigned char* data);
+};
+
+namespace { _SkyWriter Skywriter; }
+
+#endif


### PR DESCRIPTION
This feature required the core find-lib process to change as such: 
> Instead of searching for the properties file to determine whether a library is found or not, its' root directory is searched instead.

Due to latest refactoring changes, the `add_arduino_library` also handles finding the properties file itself, so all the `find_arduino_library` function does now is gather the required sources and headers.

An example of a library without a properties file has also been added, testing against the **Skywriter** library.

This PR also fixed a potential bug where the **utility** sub-dir hasn't been searched for libraries that conform to the 1.0 standard, which is against what specified in the Arduino specs.

At last, it's now also possible to find libraries under cmake's source directory and project directory.
The **libraries** and **dependencies** sub-directories are also searched under each general search path.
The source directory is the directory from which the **CMakeLists.txt** file is executed.

Fixes #28 