### PR TITLE
Fixed compiler flags not being set on library targets

### DIFF
--- a/cmake/Platform/Libraries/LibraryFlagsManager.cmake
+++ b/cmake/Platform/Libraries/LibraryFlagsManager.cmake
@@ -9,11 +9,9 @@ function(set_library_flags _library_target _board_id)
     parse_scope_argument(scope "${ARGN}"
             DEFAULT_SCOPE PUBLIC)
 
-    # Set C++ compiler flags
-    get_cmake_compliant_language_name(cpp flags_language)
-    set_compiler_target_flags(${_library_target} "${_board_id}" ${scope} LANGUAGE ${flags_language})
+    set_compiler_target_flags(${_library_target} ${_board_id} ${scope})
 
     # Set linker flags
-    set_linker_flags(${_library_target} "${_board_id}")
+    set_linker_flags(${_library_target} ${_board_id})
 
 endfunction()

--- a/cmake/Platform/Targets/CoreLibTarget.cmake
+++ b/cmake/Platform/Targets/CoreLibTarget.cmake
@@ -64,23 +64,10 @@ endfunction()
 #=============================================================================#
 function(_set_core_lib_flags _core_target_name _board_id)
 
-    # Set Assembly compiler flags
-    get_cmake_compliant_language_name(asm flags_language)
-    set_compiler_target_flags(${_core_target_name} "${_board_id}" PUBLIC
-            LANGUAGE ${flags_language})
-
-    # Set C compiler flags
-    get_cmake_compliant_language_name(c flags_language)
-    set_compiler_target_flags(${_core_target_name} "${_board_id}" PUBLIC
-            LANGUAGE ${flags_language})
-
-    # Set C++ compiler flags
-    get_cmake_compliant_language_name(cpp flags_language)
-    set_compiler_target_flags(${_core_target_name} "${_board_id}" PUBLIC
-            LANGUAGE ${flags_language})
+    set_compiler_target_flags(${_core_target_name} ${_board_id} PUBLIC)
 
     # Set linker flags
-    set_linker_flags(${_core_target_name} "${_board_id}")
+    set_linker_flags(${_core_target_name} ${_board_id})
 
 endfunction()
 

--- a/cmake/Platform/Targets/CoreLibTarget.cmake
+++ b/cmake/Platform/Targets/CoreLibTarget.cmake
@@ -66,15 +66,17 @@ function(_set_core_lib_flags _core_target_name _board_id)
 
     # Set Assembly compiler flags
     get_cmake_compliant_language_name(asm flags_language)
-    set_compiler_target_flags(${_core_target_name} "${_board_id}" PRIVATE
+    set_compiler_target_flags(${_core_target_name} "${_board_id}" PUBLIC
             LANGUAGE ${flags_language})
+
     # Set C compiler flags
     get_cmake_compliant_language_name(c flags_language)
-    set_compiler_target_flags(${_core_target_name} "${_board_id}" PRIVATE
+    set_compiler_target_flags(${_core_target_name} "${_board_id}" PUBLIC
             LANGUAGE ${flags_language})
+
     # Set C++ compiler flags
     get_cmake_compliant_language_name(cpp flags_language)
-    set_compiler_target_flags(${_core_target_name} "${_board_id}" PRIVATE
+    set_compiler_target_flags(${_core_target_name} "${_board_id}" PUBLIC
             LANGUAGE ${flags_language})
 
     # Set linker flags


### PR DESCRIPTION
Modified the compiler flag-setting policy to set flags for all languages (ASM, C and C++) if an explicit language isn't requested. It creates an easy API to use when setting compiler flags.

Fixes #40