### PR TITLE
Fixed bug where platform libraries weren't using all of their sources

### DIFF
--- a/cmake/Platform/Other/ArchitectureSupportQuery.cmake
+++ b/cmake/Platform/Other/ArchitectureSupportQuery.cmake
@@ -42,10 +42,14 @@ function(get_unsupported_architectures _arch_list _return_var)
     list(FILTER _arch_list EXCLUDE REGEX ${ARDUINO_CMAKE_PLATFORM_ARCHITECTURE})
     set(unsupported_arch_list ${_arch_list}) # Just for better readability
 
+    if (NOT unsupported_arch_list) # The only supported architecture is our platform's architecture
+        return() # Return nothing as there are no uspported architectures
+    endif ()
+
     if (parsed_args_REGEX) # Return in regex format         
 
         foreach (arch ${unsupported_arch_list})
-            # Append every unsupported-architecture and "|" to represent "or" in regex-fomart
+            # Append an "|" to every unsupported-architecture to represent "or" in regex-fomart
             string(APPEND unsupported_archs_regex "${arch}" "|")
         endforeach ()
 

--- a/cmake/Platform/Targets/PlatformLibraryTarget.cmake
+++ b/cmake/Platform/Targets/PlatformLibraryTarget.cmake
@@ -29,8 +29,11 @@ endfunction()
 #=============================================================================#
 function(_add_platform_library _library_name _board_id)
 
-    find_header_files("${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/${_library_name}/src" lib_headers)
-    find_source_files("${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/${_library_name}/src" lib_source_files)
+    find_library_header_files("${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/${_library_name}/src"
+            lib_headers)
+    find_library_source_files("${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/${_library_name}/src"
+            lib_source_files)
+
     set(lib_sources ${lib_headers} ${lib_source_files})
 
     _add_arduino_cmake_library(${_library_name} ${_board_id} "${lib_sources}")
@@ -38,7 +41,7 @@ function(_add_platform_library _library_name _board_id)
 endfunction()
 
 #=============================================================================#
-# Links the given platform library target to the given target, be it an executable or another library.
+# Links the given platform library target to the given target.
 #       _target_name - Name of the target to link against.
 #       _library_name - Name of the library target to create, usually the platform library name.
 #       _board_id - Board ID associated with the linked Core Lib.

--- a/examples/3rd-party-library/3rd_party.cpp
+++ b/examples/3rd-party-library/3rd_party.cpp
@@ -1,11 +1,13 @@
 #include <Arduino.h>
 #include "NeoPixelTest.hpp"
 #include "GFXTest.h"
+#include "LiquidCrystalTest.hpp"
 
 void setup()
 {
     testNeoPixel();
     testGFX();
+    testLiquidCrystal();
 }
 
 void loop()

--- a/examples/3rd-party-library/CMakeLists.txt
+++ b/examples/3rd-party-library/CMakeLists.txt
@@ -5,7 +5,7 @@ get_board_id(board_id nano atmega328)
 
 # First, declare and create our executable - It'll use 4 sources
 add_arduino_executable(3rd_Party_Arduino_Library ${board_id} 3rd_party.cpp
-        NeoPixelTest.cpp GFXTest.cpp)
+        NeoPixelTest.cpp GFXTest.cpp LiquidCrystalTest.cpp)
 target_include_directories(3rd_Party_Arduino_Library PRIVATE include)
 
 # Add the "NeoPixel" library manually using the library addition API
@@ -21,7 +21,10 @@ target_source_directories(adafruit_GFX DIRS libraries/Adafruit-GFX-Library/Fonts
 # We can even automatically find a library that doesn't have a properties file!
 find_arduino_library(sky_writer Skywriter ${board_id} 3RD_PARTY)
 
+find_arduino_library(liquidCrystal LiquidCrystal_I2C ${board_id} 3RD_PARTY)
+
 # Link all libraries to our previously created target
 link_arduino_library(3rd_Party_Arduino_Library adafruit_NeoPixel ${board_id})
 link_arduino_library(3rd_Party_Arduino_Library adafruit_GFX ${board_id})
 link_arduino_library(3rd_Party_Arduino_Library sky_writer ${board_id})
+link_arduino_library(3rd_Party_Arduino_Library liquidCrystal ${board_id})

--- a/examples/3rd-party-library/CMakeLists.txt
+++ b/examples/3rd-party-library/CMakeLists.txt
@@ -21,10 +21,11 @@ target_source_directories(adafruit_GFX DIRS libraries/Adafruit-GFX-Library/Fonts
 # We can even automatically find a library that doesn't have a properties file!
 find_arduino_library(sky_writer Skywriter ${board_id} 3RD_PARTY)
 
-find_arduino_library(liquidCrystal LiquidCrystal_I2C ${board_id} 3RD_PARTY)
+# Libraries that have an inner-dependency on a platform library are also suported!
+find_arduino_library(liquid_Crystal LiquidCrystal_I2C ${board_id} 3RD_PARTY)
 
 # Link all libraries to our previously created target
 link_arduino_library(3rd_Party_Arduino_Library adafruit_NeoPixel ${board_id})
 link_arduino_library(3rd_Party_Arduino_Library adafruit_GFX ${board_id})
 link_arduino_library(3rd_Party_Arduino_Library sky_writer ${board_id})
-link_arduino_library(3rd_Party_Arduino_Library liquidCrystal ${board_id})
+link_arduino_library(3rd_Party_Arduino_Library liquid_Crystal ${board_id})

--- a/examples/3rd-party-library/LiquidCrystalTest.cpp
+++ b/examples/3rd-party-library/LiquidCrystalTest.cpp
@@ -1,0 +1,9 @@
+#include "LiquidCrystalTest.hpp"
+
+LiquidCrystal_I2C lcd(LCD_ADDRESS, LCD_COLUMNS, LCD_ROWS);
+
+void testLiquidCrystal()
+{
+    lcd.begin(LCD_COLUMNS, LCD_ROWS);
+    lcd.clear();
+}

--- a/examples/3rd-party-library/include/LiquidCrystalTest.hpp
+++ b/examples/3rd-party-library/include/LiquidCrystalTest.hpp
@@ -1,0 +1,13 @@
+#ifndef EXAMPLES_LIQUIDCRYSTALTEST_HPP
+#define EXAMPLES_LIQUIDCRYSTALTEST_HPP
+
+#include <LiquidCrystal_I2C.h>
+#include <Arduino.h>
+
+#define LCD_ADDRESS     0x27
+#define LCD_COLUMNS     20
+#define LCD_ROWS        4
+
+void testLiquidCrystal();
+
+#endif //EXAMPLES_LIQUIDCRYSTALTEST_HPP

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/LiquidCrystal_I2C.cpp
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/LiquidCrystal_I2C.cpp
@@ -1,0 +1,332 @@
+// Based on the work by DFRobot
+
+#include "LiquidCrystal_I2C.h"
+#include <inttypes.h>
+#if defined(ARDUINO) && ARDUINO >= 100
+
+#include "Arduino.h"
+
+#define printIIC(args)	Wire.write(args)
+inline size_t LiquidCrystal_I2C::write(uint8_t value) {
+	send(value, Rs);
+	return 1;
+}
+
+#else
+#include "WProgram.h"
+
+#define printIIC(args)	Wire.send(args)
+inline void LiquidCrystal_I2C::write(uint8_t value) {
+	send(value, Rs);
+}
+
+#endif
+#include "Wire.h"
+
+
+
+// When the display powers up, it is configured as follows:
+//
+// 1. Display clear
+// 2. Function set: 
+//    DL = 1; 8-bit interface data 
+//    N = 0; 1-line display 
+//    F = 0; 5x8 dot character font 
+// 3. Display on/off control: 
+//    D = 0; Display off 
+//    C = 0; Cursor off 
+//    B = 0; Blinking off 
+// 4. Entry mode set: 
+//    I/D = 1; Increment by 1
+//    S = 0; No shift 
+//
+// Note, however, that resetting the Arduino doesn't reset the LCD, so we
+// can't assume that its in that state when a sketch starts (and the
+// LiquidCrystal constructor is called).
+
+LiquidCrystal_I2C::LiquidCrystal_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows)
+{
+  _Addr = lcd_Addr;
+  _cols = lcd_cols;
+  _rows = lcd_rows;
+  _backlightval = LCD_NOBACKLIGHT;
+}
+
+void LiquidCrystal_I2C::oled_init(){
+  _oled = true;
+	init_priv();
+}
+
+void LiquidCrystal_I2C::init(){
+	init_priv();
+}
+
+void LiquidCrystal_I2C::init_priv()
+{
+	Wire.begin();
+	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
+	begin(_cols, _rows);  
+}
+
+void LiquidCrystal_I2C::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
+	if (lines > 1) {
+		_displayfunction |= LCD_2LINE;
+	}
+	_numlines = lines;
+
+	// for some 1 line displays you can select a 10 pixel high font
+	if ((dotsize != 0) && (lines == 1)) {
+		_displayfunction |= LCD_5x10DOTS;
+	}
+
+	// SEE PAGE 45/46 FOR INITIALIZATION SPECIFICATION!
+	// according to datasheet, we need at least 40ms after power rises above 2.7V
+	// before sending commands. Arduino can turn on way befer 4.5V so we'll wait 50
+	delay(50); 
+  
+	// Now we pull both RS and R/W low to begin commands
+	expanderWrite(_backlightval);	// reset expanderand turn backlight off (Bit 8 =1)
+	delay(1000);
+
+  	//put the LCD into 4 bit mode
+	// this is according to the hitachi HD44780 datasheet
+	// figure 24, pg 46
+	
+	  // we start in 8bit mode, try to set 4 bit mode
+   write4bits(0x03 << 4);
+   delayMicroseconds(4500); // wait min 4.1ms
+   
+   // second try
+   write4bits(0x03 << 4);
+   delayMicroseconds(4500); // wait min 4.1ms
+   
+   // third go!
+   write4bits(0x03 << 4); 
+   delayMicroseconds(150);
+   
+   // finally, set to 4-bit interface
+   write4bits(0x02 << 4); 
+
+
+	// set # lines, font size, etc.
+	command(LCD_FUNCTIONSET | _displayfunction);  
+	
+	// turn the display on with no cursor or blinking default
+	_displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
+	display();
+	
+	// clear it off
+	clear();
+	
+	// Initialize to default text direction (for roman languages)
+	_displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+	
+	// set the entry mode
+	command(LCD_ENTRYMODESET | _displaymode);
+	
+	home();
+  
+}
+
+/********** high level commands, for the user! */
+void LiquidCrystal_I2C::clear(){
+	command(LCD_CLEARDISPLAY);// clear display, set cursor position to zero
+	delayMicroseconds(2000);  // this command takes a long time!
+  if (_oled) setCursor(0,0);
+}
+
+void LiquidCrystal_I2C::home(){
+	command(LCD_RETURNHOME);  // set cursor position to zero
+	delayMicroseconds(2000);  // this command takes a long time!
+}
+
+void LiquidCrystal_I2C::setCursor(uint8_t col, uint8_t row){
+	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
+	if ( row > _numlines ) {
+		row = _numlines-1;    // we count rows starting w/0
+	}
+	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
+}
+
+// Turn the display on/off (quickly)
+void LiquidCrystal_I2C::noDisplay() {
+	_displaycontrol &= ~LCD_DISPLAYON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+void LiquidCrystal_I2C::display() {
+	_displaycontrol |= LCD_DISPLAYON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+// Turns the underline cursor on/off
+void LiquidCrystal_I2C::noCursor() {
+	_displaycontrol &= ~LCD_CURSORON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+void LiquidCrystal_I2C::cursor() {
+	_displaycontrol |= LCD_CURSORON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+// Turn on and off the blinking cursor
+void LiquidCrystal_I2C::noBlink() {
+	_displaycontrol &= ~LCD_BLINKON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+void LiquidCrystal_I2C::blink() {
+	_displaycontrol |= LCD_BLINKON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
+}
+
+// These commands scroll the display without changing the RAM
+void LiquidCrystal_I2C::scrollDisplayLeft(void) {
+	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
+}
+void LiquidCrystal_I2C::scrollDisplayRight(void) {
+	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
+}
+
+// This is for text that flows Left to Right
+void LiquidCrystal_I2C::leftToRight(void) {
+	_displaymode |= LCD_ENTRYLEFT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// This is for text that flows Right to Left
+void LiquidCrystal_I2C::rightToLeft(void) {
+	_displaymode &= ~LCD_ENTRYLEFT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// This will 'right justify' text from the cursor
+void LiquidCrystal_I2C::autoscroll(void) {
+	_displaymode |= LCD_ENTRYSHIFTINCREMENT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// This will 'left justify' text from the cursor
+void LiquidCrystal_I2C::noAutoscroll(void) {
+	_displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
+	command(LCD_ENTRYMODESET | _displaymode);
+}
+
+// Allows us to fill the first 8 CGRAM locations
+// with custom characters
+void LiquidCrystal_I2C::createChar(uint8_t location, uint8_t charmap[]) {
+	location &= 0x7; // we only have 8 locations 0-7
+	command(LCD_SETCGRAMADDR | (location << 3));
+	for (int i=0; i<8; i++) {
+		write(charmap[i]);
+	}
+}
+
+//createChar with PROGMEM input
+void LiquidCrystal_I2C::createChar(uint8_t location, const char *charmap) {
+	location &= 0x7; // we only have 8 locations 0-7
+	command(LCD_SETCGRAMADDR | (location << 3));
+	for (int i=0; i<8; i++) {
+	    	write(pgm_read_byte_near(charmap++));
+	}
+}
+
+// Turn the (optional) backlight off/on
+void LiquidCrystal_I2C::noBacklight(void) {
+	_backlightval=LCD_NOBACKLIGHT;
+	expanderWrite(0);
+}
+
+void LiquidCrystal_I2C::backlight(void) {
+	_backlightval=LCD_BACKLIGHT;
+	expanderWrite(0);
+}
+
+
+
+/*********** mid level commands, for sending data/cmds */
+
+inline void LiquidCrystal_I2C::command(uint8_t value) {
+	send(value, 0);
+}
+
+
+/************ low level data pushing commands **********/
+
+// write either command or data
+void LiquidCrystal_I2C::send(uint8_t value, uint8_t mode) {
+	uint8_t highnib=value&0xf0;
+	uint8_t lownib=(value<<4)&0xf0;
+       write4bits((highnib)|mode);
+	write4bits((lownib)|mode); 
+}
+
+void LiquidCrystal_I2C::write4bits(uint8_t value) {
+	expanderWrite(value);
+	pulseEnable(value);
+}
+
+void LiquidCrystal_I2C::expanderWrite(uint8_t _data){                                        
+	Wire.beginTransmission(_Addr);
+	printIIC((int)(_data) | _backlightval);
+	Wire.endTransmission();   
+}
+
+void LiquidCrystal_I2C::pulseEnable(uint8_t _data){
+	expanderWrite(_data | En);	// En high
+	delayMicroseconds(1);		// enable pulse must be >450ns
+	
+	expanderWrite(_data & ~En);	// En low
+	delayMicroseconds(50);		// commands need > 37us to settle
+} 
+
+
+// Alias functions
+
+void LiquidCrystal_I2C::cursor_on(){
+	cursor();
+}
+
+void LiquidCrystal_I2C::cursor_off(){
+	noCursor();
+}
+
+void LiquidCrystal_I2C::blink_on(){
+	blink();
+}
+
+void LiquidCrystal_I2C::blink_off(){
+	noBlink();
+}
+
+void LiquidCrystal_I2C::load_custom_character(uint8_t char_num, uint8_t *rows){
+		createChar(char_num, rows);
+}
+
+void LiquidCrystal_I2C::setBacklight(uint8_t new_val){
+	if(new_val){
+		backlight();		// turn backlight on
+	}else{
+		noBacklight();		// turn backlight off
+	}
+}
+
+void LiquidCrystal_I2C::printstr(const char c[]){
+	//This function is not identical to the function used for "real" I2C displays
+	//it's here so the user sketch doesn't have to be changed 
+	print(c);
+}
+
+
+// unsupported API functions
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+void LiquidCrystal_I2C::off(){}
+void LiquidCrystal_I2C::on(){}
+void LiquidCrystal_I2C::setDelay (int cmdDelay,int charDelay) {}
+uint8_t LiquidCrystal_I2C::status(){return 0;}
+uint8_t LiquidCrystal_I2C::keypad (){return 0;}
+uint8_t LiquidCrystal_I2C::init_bargraph(uint8_t graphtype){return 0;}
+void LiquidCrystal_I2C::draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_col_end){}
+void LiquidCrystal_I2C::draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_row_end){}
+void LiquidCrystal_I2C::setContrast(uint8_t new_val){}
+#pragma GCC diagnostic pop
+	

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/LiquidCrystal_I2C.h
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/LiquidCrystal_I2C.h
@@ -1,0 +1,131 @@
+//YWROBOT
+#ifndef LiquidCrystal_I2C_h
+#define LiquidCrystal_I2C_h
+
+#include <inttypes.h>
+#include "Print.h" 
+#include <Wire.h>
+
+// commands
+#define LCD_CLEARDISPLAY 0x01
+#define LCD_RETURNHOME 0x02
+#define LCD_ENTRYMODESET 0x04
+#define LCD_DISPLAYCONTROL 0x08
+#define LCD_CURSORSHIFT 0x10
+#define LCD_FUNCTIONSET 0x20
+#define LCD_SETCGRAMADDR 0x40
+#define LCD_SETDDRAMADDR 0x80
+
+// flags for display entry mode
+#define LCD_ENTRYRIGHT 0x00
+#define LCD_ENTRYLEFT 0x02
+#define LCD_ENTRYSHIFTINCREMENT 0x01
+#define LCD_ENTRYSHIFTDECREMENT 0x00
+
+// flags for display on/off control
+#define LCD_DISPLAYON 0x04
+#define LCD_DISPLAYOFF 0x00
+#define LCD_CURSORON 0x02
+#define LCD_CURSOROFF 0x00
+#define LCD_BLINKON 0x01
+#define LCD_BLINKOFF 0x00
+
+// flags for display/cursor shift
+#define LCD_DISPLAYMOVE 0x08
+#define LCD_CURSORMOVE 0x00
+#define LCD_MOVERIGHT 0x04
+#define LCD_MOVELEFT 0x00
+
+// flags for function set
+#define LCD_8BITMODE 0x10
+#define LCD_4BITMODE 0x00
+#define LCD_2LINE 0x08
+#define LCD_1LINE 0x00
+#define LCD_5x10DOTS 0x04
+#define LCD_5x8DOTS 0x00
+
+// flags for backlight control
+#define LCD_BACKLIGHT 0x08
+#define LCD_NOBACKLIGHT 0x00
+
+#define En B00000100  // Enable bit
+#define Rw B00000010  // Read/Write bit
+#define Rs B00000001  // Register select bit
+
+class LiquidCrystal_I2C : public Print {
+public:
+  LiquidCrystal_I2C(uint8_t lcd_Addr,uint8_t lcd_cols,uint8_t lcd_rows);
+  void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS );
+  void clear();
+  void home();
+  void noDisplay();
+  void display();
+  void noBlink();
+  void blink();
+  void noCursor();
+  void cursor();
+  void scrollDisplayLeft();
+  void scrollDisplayRight();
+  void printLeft();
+  void printRight();
+  void leftToRight();
+  void rightToLeft();
+  void shiftIncrement();
+  void shiftDecrement();
+  void noBacklight();
+  void backlight();
+  void autoscroll();
+  void noAutoscroll(); 
+  void createChar(uint8_t, uint8_t[]);
+  void createChar(uint8_t location, const char *charmap);
+  // Example: 	const char bell[8] PROGMEM = {B00100,B01110,B01110,B01110,B11111,B00000,B00100,B00000};
+  
+  void setCursor(uint8_t, uint8_t); 
+#if defined(ARDUINO) && ARDUINO >= 100
+  virtual size_t write(uint8_t);
+#else
+  virtual void write(uint8_t);
+#endif
+  void command(uint8_t);
+  void init();
+  void oled_init();
+
+////compatibility API function aliases
+void blink_on();						// alias for blink()
+void blink_off();       					// alias for noBlink()
+void cursor_on();      	 					// alias for cursor()
+void cursor_off();      					// alias for noCursor()
+void setBacklight(uint8_t new_val);				// alias for backlight() and nobacklight()
+void load_custom_character(uint8_t char_num, uint8_t *rows);	// alias for createChar()
+void printstr(const char[]);
+
+////Unsupported API functions (not implemented in this library)
+uint8_t status();
+void setContrast(uint8_t new_val);
+uint8_t keypad();
+void setDelay(int,int);
+void on();
+void off();
+uint8_t init_bargraph(uint8_t graphtype);
+void draw_horizontal_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_col_end);
+void draw_vertical_graph(uint8_t row, uint8_t column, uint8_t len,  uint8_t pixel_col_end);
+	 
+
+private:
+  void init_priv();
+  void send(uint8_t, uint8_t);
+  void write4bits(uint8_t);
+  void expanderWrite(uint8_t);
+  void pulseEnable(uint8_t);
+  uint8_t _Addr;
+  uint8_t _displayfunction;
+  uint8_t _displaycontrol;
+  uint8_t _displaymode;
+  uint8_t _numlines;
+  bool _oled = false;
+  uint8_t _cols;
+  uint8_t _rows;
+  uint8_t _backlightval;
+};
+
+#endif

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/examples/CustomChars/CustomChars.pde
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/examples/CustomChars/CustomChars.pde
@@ -1,0 +1,70 @@
+//YWROBOT
+//Compatible with the Arduino IDE 1.0
+//Library version:1.1
+#include <Wire.h>
+#include <LiquidCrystal_I2C.h>
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#define printByte(args)  write(args);
+#else
+#define printByte(args)  print(args,BYTE);
+#endif
+
+uint8_t bell[8]  = {0x4,0xe,0xe,0xe,0x1f,0x0,0x4};
+uint8_t note[8]  = {0x2,0x3,0x2,0xe,0x1e,0xc,0x0};
+uint8_t clock[8] = {0x0,0xe,0x15,0x17,0x11,0xe,0x0};
+uint8_t heart[8] = {0x0,0xa,0x1f,0x1f,0xe,0x4,0x0};
+uint8_t duck[8]  = {0x0,0xc,0x1d,0xf,0xf,0x6,0x0};
+uint8_t check[8] = {0x0,0x1,0x3,0x16,0x1c,0x8,0x0};
+uint8_t cross[8] = {0x0,0x1b,0xe,0x4,0xe,0x1b,0x0};
+uint8_t retarrow[8] = {	0x1,0x1,0x5,0x9,0x1f,0x8,0x4};
+  
+LiquidCrystal_I2C lcd(0x27,20,4);  // set the LCD address to 0x27 for a 16 chars and 2 line display
+
+void setup()
+{
+  lcd.init();                      // initialize the lcd 
+  lcd.backlight();
+  
+  lcd.createChar(0, bell);
+  lcd.createChar(1, note);
+  lcd.createChar(2, clock);
+  lcd.createChar(3, heart);
+  lcd.createChar(4, duck);
+  lcd.createChar(5, check);
+  lcd.createChar(6, cross);
+  lcd.createChar(7, retarrow);
+  lcd.home();
+  
+  lcd.print("Hello world...");
+  lcd.setCursor(0, 1);
+  lcd.print(" i ");
+  lcd.printByte(3);
+  lcd.print(" arduinos!");
+  delay(5000);
+  displayKeyCodes();
+  
+}
+
+// display all keycodes
+void displayKeyCodes(void) {
+  uint8_t i = 0;
+  while (1) {
+    lcd.clear();
+    lcd.print("Codes 0x"); lcd.print(i, HEX);
+    lcd.print("-0x"); lcd.print(i+15, HEX);
+    lcd.setCursor(0, 1);
+    for (int j=0; j<16; j++) {
+      lcd.printByte(i+j);
+    }
+    i+=16;
+    
+    delay(4000);
+  }
+}
+
+void loop()
+{
+
+}
+

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/examples/HelloWorld/HelloWorld.pde
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/examples/HelloWorld/HelloWorld.pde
@@ -1,0 +1,26 @@
+//YWROBOT
+//Compatible with the Arduino IDE 1.0
+//Library version:1.1
+#include <LiquidCrystal_I2C.h>
+
+LiquidCrystal_I2C lcd(0x27,20,4);  // set the LCD address to 0x27 for a 16 chars and 2 line display
+
+void setup()
+{
+  lcd.init();                      // initialize the lcd 
+  // Print a message to the LCD.
+  lcd.backlight();
+  lcd.setCursor(3,0);
+  lcd.print("Hello, world!");
+  lcd.setCursor(2,1);
+  lcd.print("Ywrobot Arduino!");
+   lcd.setCursor(0,2);
+  lcd.print("Arduino LCM IIC 2004");
+   lcd.setCursor(2,3);
+  lcd.print("Power By Ec-yuan!");
+}
+
+
+void loop()
+{
+}

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/examples/SerialDisplay/SerialDisplay.pde
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/examples/SerialDisplay/SerialDisplay.pde
@@ -1,0 +1,34 @@
+/*
+ * Displays text sent over the serial port (e.g. from the Serial Monitor) on
+ * an attached LCD.
+ * YWROBOT
+ *Compatible with the Arduino IDE 1.0
+ *Library version:1.1
+ */
+#include <Wire.h> 
+#include <LiquidCrystal_I2C.h>
+
+LiquidCrystal_I2C lcd(0x27,20,4);  // set the LCD address to 0x27 for a 16 chars and 2 line display
+
+void setup()
+{
+  lcd.init();                      // initialize the lcd 
+  lcd.backlight();
+  Serial.begin(9600);
+}
+
+void loop()
+{
+  // when characters arrive over the serial port...
+  if (Serial.available()) {
+    // wait a bit for the entire message to arrive
+    delay(100);
+    // clear the screen
+    lcd.clear();
+    // read all the available characters
+    while (Serial.available() > 0) {
+      // display each character to the LCD
+      lcd.write(Serial.read());
+    }
+  }
+}

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/keywords.txt
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/keywords.txt
@@ -1,0 +1,46 @@
+###########################################
+# Syntax Coloring Map For LiquidCrystal_I2C
+###########################################
+
+###########################################
+# Datatypes (KEYWORD1)
+###########################################
+
+LiquidCrystal_I2C	KEYWORD1
+
+###########################################
+# Methods and Functions (KEYWORD2)
+###########################################
+init	KEYWORD2
+begin	KEYWORD2
+clear	KEYWORD2
+home	KEYWORD2
+noDisplay	KEYWORD2
+display	KEYWORD2
+noBlink	KEYWORD2
+blink	KEYWORD2
+noCursor	KEYWORD2
+cursor	KEYWORD2
+scrollDisplayLeft	KEYWORD2
+scrollDisplayRight	KEYWORD2
+leftToRight	KEYWORD2
+rightToLeft	KEYWORD2
+shiftIncrement	KEYWORD2
+shiftDecrement	KEYWORD2
+noBacklight	KEYWORD2
+backlight	KEYWORD2
+autoscroll	KEYWORD2
+noAutoscroll	KEYWORD2
+createChar	KEYWORD2
+setCursor	KEYWORD2
+print	KEYWORD2
+blink_on	KEYWORD2
+blink_off	KEYWORD2
+cursor_on	KEYWORD2
+cursor_off	KEYWORD2
+setBacklight	KEYWORD2
+load_custom_character	KEYWORD2
+printstr	KEYWORD2
+###########################################
+# Constants (LITERAL1)
+###########################################

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/library.json
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/library.json
@@ -1,0 +1,16 @@
+{
+  "name": "LiquidCrystal_I2C",
+  "keywords": "LCD, liquidcrystal, I2C",
+  "description": "A library for DFRobot I2C LCD displays",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/marcoschwartz/LiquidCrystal_I2C.git"
+  },
+  "frameworks": "arduino",
+  "platforms":
+  [
+    "atmelavr",
+    "espressif8266"
+  ]
+}

--- a/examples/3rd-party-library/libraries/LiquidCrystal_I2C/library.properties
+++ b/examples/3rd-party-library/libraries/LiquidCrystal_I2C/library.properties
@@ -1,0 +1,9 @@
+name=LiquidCrystal_I2C
+version=1.1.4
+author=Frank de Brabander
+maintainer=Marco Schwartz <marcolivier.schwartz@gmail.com>
+sentence=A library for I2C LCD displays.
+paragraph= The library allows to control I2C displays with functions extremely similar to LiquidCrystal library. THIS LIBRARY MIGHT NOT BE COMPATIBLE WITH EXISTING SKETCHES.
+category=Display
+url=https://github.com/marcoschwartz/LiquidCrystal_I2C
+architectures=avr


### PR DESCRIPTION
Only the root directory of a platform library were searched for sources, even if a **utility** sub-directory exists. 
This is fixed now as the same search algorithm used for **Arduino Libraries** is applied here as well.

Also fixed a bug where libraries that support a single architecture which happens to be the platform architecture weren't supported - This case wasn't covered in the cmake code.

Fixes #43.