### PR TITLE
Refactored upload API

### DIFF
--- a/cmake/Platform/Targets/UploadTarget.cmake
+++ b/cmake/Platform/Targets/UploadTarget.cmake
@@ -3,7 +3,7 @@
 #       _target_name - Name of the target (Executable) to upload.
 #       _port - Serial port on the host system used to upload/flash the connected Arduino board.
 #=============================================================================#
-function(upload_arduino_target _target_name _port)
+function(set_target_upload_port _target_name _port)
 
     if ("${_target_name}" STREQUAL "")
         message(FATAL_ERROR "Can't create upload target for an invalid target ${_target_name}")
@@ -11,10 +11,10 @@ function(upload_arduino_target _target_name _port)
 
     set_upload_target_flags(${_target_name} ${_port} upload_args)
 
-    add_custom_command(TARGET ${_target_name} POST_BUILD
-            COMMAND ${ARDUINO_CMAKE_AVRDUDE_PROGRAM}
-            ARGS ${upload_args}
-            COMMENT "Uploading ${_target_name} target"
-            DEPENDS ${_target_name})
+    add_custom_target(${_target_name}_flash
+            COMMAND ${ARDUINO_CMAKE_AVRDUDE_PROGRAM} ${upload_args}
+            COMMENT "Uploading ${_target_name} target")
+
+    add_dependencies(${_target_name}_flash ${_target_name})
 
 endfunction()

--- a/cmake/Platform/Targets/UploadTarget.cmake
+++ b/cmake/Platform/Targets/UploadTarget.cmake
@@ -5,8 +5,13 @@
 #=============================================================================#
 function(set_target_upload_port _target_name _port)
 
-    if ("${_target_name}" STREQUAL "")
+    if (NOT TARGET ${_target_name})
         message(FATAL_ERROR "Can't create upload target for an invalid target ${_target_name}")
+    else ()
+        get_target_property(target_type ${_target_name} TYPE)
+        if (NOT ${target_type} STREQUAL "EXECUTABLE") # Target is not executable
+            message(SEND_ERROR "Upload target ${_target_name} must be an executable target")
+        endif ()
     endif ()
 
     set_upload_target_flags(${_target_name} ${_port} upload_args)

--- a/examples/hello-world/CMakeLists.txt
+++ b/examples/hello-world/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.2)
 
 project(Hello_World)
 
-arduino_cmake_project(Hello_World BOARD_NAME nano BOARD_CPU atmega328old)
+arduino_cmake_project(Hello_World BOARD_NAME uno)
 
 add_arduino_executable(Hello_World helloWorld.cpp)
 

--- a/examples/hello-world/CMakeLists.txt
+++ b/examples/hello-world/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 project(Hello_World)
-#get_board_id(board_id nano atmega328)
 
-arduino_cmake_project(Hello_World BOARD_NAME nano BOARD_CPU atmega328)
+arduino_cmake_project(Hello_World BOARD_NAME nano BOARD_CPU atmega328old)
 
-add_arduino_executable(Hello_World ${board_id} helloWorld.cpp)
+add_arduino_executable(Hello_World helloWorld.cpp)
 
-#upload_arduino_target(Hello_World "${board_id}" COM3)
+set_target_upload_port(Hello_World COM3)


### PR DESCRIPTION
This works refactors the upload API by creating a target dedicated for uploading rather than executing a command whenever CMake is run. This is a somewhat standard behavior in common frameworks.
The new upload target is named after the source target and append **flash** to its end.
Besides, the `upload_arduino_target` function has been renamed to `set_upload_target_port` as it describes more clearly what does it do. It's important to note that the target is created _**inside**_ this function.

Closes #73 