### PR TITLE
Standardized platform library API

### DIFF
--- a/cmake/Platform/Libraries/LibrariesFinder.cmake
+++ b/cmake/Platform/Libraries/LibrariesFinder.cmake
@@ -21,7 +21,9 @@ function(find_arduino_library _target_name _library_name)
     set(argument_options "3RD_PARTY" "HEADER_ONLY" "QUIET")
     cmake_parse_arguments(parsed_args "${argument_options}" "" "" ${ARGN})
 
-    if (NOT parsed_args_3RD_PARTY)
+    is_platform_library(${_library_name} is_plib) # Detect whether library is a platform library
+
+    if (NOT parsed_args_3RD_PARTY AND NOT is_plib)
         convert_string_to_pascal_case(${_library_name} _library_name)
     endif ()
 
@@ -47,11 +49,9 @@ function(find_arduino_library _target_name _library_name)
                 message(SEND_ERROR "Couldn't find any header files for the "
                         "${_library_name} library")
             endif ()
-
         else ()
             if (parsed_args_HEADER_ONLY)
                 add_arduino_header_only_library(${_target_name} ${library_headers})
-
             else ()
                 find_library_source_files("${library_path}" library_sources)
 
@@ -68,15 +68,12 @@ function(find_arduino_library _target_name _library_name)
                 else ()
                     set(sources ${library_headers} ${library_sources})
 
-                    is_platform_library(${_library_name} is_plib)
                     if (is_plib)
                         add_arduino_library(${_target_name} PLATFORM ${sources})
                     else ()
                         add_arduino_library(${_target_name} ${sources})
                     endif ()
-
                 endif ()
-
             endif ()
         endif ()
     endif ()

--- a/cmake/Platform/Libraries/LibrariesFinder.cmake
+++ b/cmake/Platform/Libraries/LibrariesFinder.cmake
@@ -27,8 +27,8 @@ function(find_arduino_library _target_name _library_name)
 
     find_file(library_path
             NAMES ${_library_name}
-            PATHS ${ARDUINO_SDK_LIBRARIES_PATH} ${ARDUINO_CMAKE_SKETCHBOOK_PATH}
-            ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}
+            PATHS ${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH} ${ARDUINO_SDK_LIBRARIES_PATH}
+            ${ARDUINO_CMAKE_SKETCHBOOK_PATH} ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}
             PATH_SUFFIXES libraries dependencies
             NO_DEFAULT_PATH
             NO_CMAKE_FIND_ROOT_PATH)
@@ -37,7 +37,6 @@ function(find_arduino_library _target_name _library_name)
         message(SEND_ERROR "Couldn't find library named ${_library_name}")
 
     else () # Library is found
-
         find_library_header_files("${library_path}" library_headers)
 
         if (NOT library_headers)
@@ -50,12 +49,10 @@ function(find_arduino_library _target_name _library_name)
             endif ()
 
         else ()
-
             if (parsed_args_HEADER_ONLY)
                 add_arduino_header_only_library(${_target_name} ${library_headers})
 
             else ()
-
                 find_library_source_files("${library_path}" library_sources)
 
                 if (NOT library_sources)
@@ -68,19 +65,20 @@ function(find_arduino_library _target_name _library_name)
                                 "If so, please pass the HEADER_ONLY option "
                                 "as an argument to the function")
                     endif ()
-
                 else ()
-
                     set(sources ${library_headers} ${library_sources})
 
-                    add_arduino_library(${_target_name} ${sources})
+                    is_platform_library(${_library_name} is_plib)
+                    if (is_plib)
+                        add_arduino_library(${_target_name} PLATFORM ${sources})
+                    else ()
+                        add_arduino_library(${_target_name} ${sources})
+                    endif ()
 
                 endif ()
 
             endif ()
-
         endif ()
-
     endif ()
 
     _cleanup_find_arduino_library()

--- a/cmake/Platform/System/PlatformElementsManager.cmake
+++ b/cmake/Platform/System/PlatformElementsManager.cmake
@@ -118,19 +118,20 @@ function(find_platform_libraries)
             NO_CMAKE_FIND_ROOT_PATH)
 
     file(GLOB sub-dir "${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/*")
-    set(platform_lib_list)
+
     foreach (dir ${sub-dir})
         if (IS_DIRECTORY ${dir})
             get_filename_component(platform_lib ${dir} NAME)
             string(TOLOWER ${platform_lib} platform_lib)
+
             set(ARDUINO_CMAKE_LIBRARY_${platform_lib}_PATH ${dir} CACHE INTERNAL
                     "Path to ${platform_lib} platform library")
+
             list(APPEND platform_lib_list ${platform_lib})
         endif ()
     endforeach ()
 
-    set(ARDUINO_CMAKE_PLATFORM_LIBRARIES "${platform_lib_list}" CACHE STRING
-            "List of existing platform libraries")
+    set(ARDUINO_CMAKE_PLATFORM_LIBRARIES "${platform_lib_list}" CACHE STRING "List of existing platform libraries")
 
 endfunction()
 

--- a/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
+++ b/cmake/Platform/Targets/ArduinoLibraryTarget.cmake
@@ -2,12 +2,16 @@
 # Creates a library target for the given name and sources.
 # As it's an Arduino library, it also finds and links all dependent platform libraries (if any).
 #       _target_name - Name of the library target to be created. Usually library's real name.
+#       [PLATFORM] -
 #       [Sources] - List of source files (Could also be headers for code-inspection in some IDEs)
 #                   to create the executable from, similar to CMake's built-in add_executable.
 #=============================================================================#
 function(add_arduino_library _target_name)
 
-    parse_sources_arguments(parsed_sources "" "" "" "${ARGN}")
+    # First parse keyword arguments
+    cmake_parse_arguments(parsed_args "PLATFORM" "" "" ${ARGN})
+    # Then parse unlimited sources
+    parse_sources_arguments(parsed_sources "PLATFORM" "" "" "${ARGN}")
 
     if (parsed_sources)
 
@@ -23,9 +27,13 @@ function(add_arduino_library _target_name)
 
         _add_arduino_cmake_library(${_target_name} "${arch_resolved_sources}")
 
-    else() # No sources have been provided at this stage, simply create a library target
+    else () # No sources have been provided at this stage, simply create a library target
         _add_arduino_cmake_library(${_target_name} "")
-    endif()
+    endif ()
+
+    if (parsed_args_PLATFORM)
+        return()
+    endif ()
 
     find_dependent_platform_libraries("${arch_resolved_sources}" lib_platform_libs)
 

--- a/cmake/Platform/Targets/PlatformLibraryTarget.cmake
+++ b/cmake/Platform/Targets/PlatformLibraryTarget.cmake
@@ -24,16 +24,17 @@ endfunction()
 
 #=============================================================================#
 # Creates a platform library target with the given name.
+#       _target_name - Name of the target to link against.
 #       _library_name - Name of the library target to create, usually the platform library name.
 #=============================================================================#
-function(_add_platform_library _library_name)
+function(_add_target_dependent_platform_library _target_name _library_name)
 
     find_library_header_files("${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/${_library_name}/src" lib_headers)
     find_library_source_files("${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH}/${_library_name}/src" lib_source_files)
 
     set(lib_sources ${lib_headers} ${lib_source_files})
 
-    _add_arduino_cmake_library(${_library_name} "${lib_sources}")
+    _add_arduino_cmake_library("${_target_name}_${_library_name}" "${lib_sources}")
 
 endfunction()
 
@@ -53,9 +54,9 @@ function(link_platform_library _target_name _platform_library_name)
 
     if (NOT TARGET ${_platform_library_name})
 
-        _add_platform_library(${_platform_library_name})
+        _add_target_dependent_platform_library(${_target_name} ${_platform_library_name})
 
-        _link_arduino_cmake_library(${_target_name} ${_platform_library_name}
+        _link_arduino_cmake_library(${_target_name} "${_target_name}_${_platform_library_name}"
                 ${scope}
                 BOARD_CORE_TARGET ${${PROJECT_${ARDUINO_CMAKE_PROJECT_NAME}_BOARD}_CORELIB_TARGET})
 

--- a/examples/platform-library/CMakeLists.txt
+++ b/examples/platform-library/CMakeLists.txt
@@ -6,5 +6,8 @@ arduino_cmake_project(Platform_Library BOARD_NAME nano BOARD_CPU atmega328)
 
 add_arduino_executable(Platform_Library platformLibrary.cpp)
 
-link_platform_library(Platform_Library Wire)
-link_platform_library(Platform_Library SPI)
+find_arduino_library(wire Wire)
+link_arduino_library(Platform_Library wire)
+
+find_arduino_library(spi SPI)
+link_arduino_library(Platform_Library spi)

--- a/examples/platform-library/platformLibrary.cpp
+++ b/examples/platform-library/platformLibrary.cpp
@@ -1,8 +1,11 @@
 #include <Arduino.h>
+#include <Wire.h>
+#include <SPI.h>
 
 void setup()
 {
     pinMode(LED_BUILTIN, OUTPUT);
+    SPIClass::setDataMode(0);
 }
 
 void loop()


### PR DESCRIPTION
Removed the need to use exclusive functions to work with platform libraries.
Now they're to be found using `find_arduino_library` and then linked using `link_arduino_library` - Just as one would normally do with Arduino libraries.

Closes #66