### PR TITLE
Arch linux support

### DIFF
--- a/cmake/Arduino-Toolchain.cmake
+++ b/cmake/Arduino-Toolchain.cmake
@@ -37,9 +37,11 @@ endfunction()
 
 function(_setup_sdk_internal_paths)
 
-    set(ARDUINO_SDK_BIN_PATH "${ARDUINO_SDK_PATH}/hardware/tools/avr/bin" CACHE PATH
+    find_arduino_sdk_bin(arduino_bin_path)
+    set(ARDUINO_SDK_BIN_PATH "${arduino_bin_path}" CACHE PATH
             "Path to Arduino SDK's binaries folder")
-    set(ARDUINO_SDK_ROOT_PATH "${ARDUINO_SDK_PATH}/hardware/tools/avr" CACHE PATH
+    find_arduino_sdk_root(arduino_root_path)
+    set(ARDUINO_SDK_ROOT_PATH "${arduino_root_path}" CACHE PATH
             "Path to Arduino SDK's sys-root folder")
     set(ARDUINO_SDK_LIBRARIES_PATH "${ARDUINO_SDK_PATH}/libraries" CACHE PATH
             "Path to SDK's libraries directory")

--- a/cmake/Platform/Other/ArduinoSDKSeeker.cmake
+++ b/cmake/Platform/Other/ArduinoSDKSeeker.cmake
@@ -58,14 +58,14 @@ function(find_arduino_sdk_bin _return_var)
     else ()
         # Some systems like the Arch Linux arduino package install binaries to /usr/bin
         find_program(avr_gcc_location avr-gcc)
-        if (avr_gcc_location)
-            get_filename_component(avr_gcc_parent ${avr_gcc_location} DIRECTORY)
-            set(${_return_var} "${avr_gcc_parent}" PARENT_SCOPE)
-        else ()
+        if ("${avr_gcc_location}" MATCHES "NOTFOUND")
             string(CONCAT error_message
                     "Couldn't find Arduino bin path - Is it in a non-standard location?" "\n"
                     "If so, please set the ARDUINO_SDK_BIN_PATH CMake-Variable")
             message(FATAL_ERROR ${error_message})
+        else ()
+            get_filename_component(avr_gcc_parent ${avr_gcc_location} DIRECTORY)
+            set(${_return_var} "${avr_gcc_parent}" PARENT_SCOPE)
         endif ()
     endif ()
 

--- a/cmake/Platform/Other/ArduinoSDKSeeker.cmake
+++ b/cmake/Platform/Other/ArduinoSDKSeeker.cmake
@@ -40,3 +40,43 @@ function(find_arduino_sdk _return_var)
 
 endfunction()
 
+function(find_arduino_sdk_bin _return_var)
+
+    if (DEFINED ENV{ARDUINO_SDK_BIN_PATH})
+        string(REPLACE "\\" "/" unix_style_sdk_bin_path $ENV{ARDUINO_SDK_BIN_PATH})
+        set(${_return_var} "${unix_style_sdk_bin_path}" PARENT_SCOPE)
+    elseif (IS_DIRECTORY "${ARDUINO_SDK_PATH}/hardware/tools/avr/bin")
+        set(${_return_var} "${ARDUINO_SDK_PATH}/hardware/tools/avr/bin" PARENT_SCOPE)
+    else ()
+        # Some systems like the Arch Linux arduino package install binaries to /usr/bin
+        find_program(avr_gcc_location avr-gcc)
+        if (avr_gcc_location)
+            get_filename_component(avr_gcc_parent ${avr_gcc_location} DIRECTORY)
+            set(${_return_var} "${avr_gcc_parent}" PARENT_SCOPE)
+        else ()
+            string(CONCAT error_message
+                    "Couldn't find Arduino bin path - Is it in a non-standard location?" "\n"
+                    "If so, please set the ARDUINO_SDK_BIN_PATH CMake-Variable")
+            message(FATAL_ERROR ${error_message})
+        endif ()
+    endif ()
+
+endfunction()
+
+function(find_arduino_sdk_root _return_var)
+
+    if (DEFINED ENV{ARDUINO_SDK_ROOT_PATH})
+        string(REPLACE "\\" "/" unix_style_sdk_root_path $ENV{ARDUINO_SDK_ROOT_PATH})
+        set(${_return_var} "${unix_style_sdk_root_path}" PARENT_SCOPE)
+    elseif (EXISTS "${ARDUINO_SDK_PATH}/hardware/tools/avr/etc/avrdude.conf")
+        set(${_return_var} "${ARDUINO_SDK_PATH}/hardware/tools/avr" PARENT_SCOPE)
+    elseif (EXISTS "/etc/avrdude.conf")
+        set(${_return_var} "/" PARENT_SCOPE)
+    else ()
+        string(CONCAT error_message
+                "Couldn't find Arduino root path - Is it in a non-standard location?" "\n"
+                "If so, please set the ARDUINO_SDK_ROOT_PATH CMake-Variable")
+        message(FATAL_ERROR ${error_message})
+    endif ()
+
+endfunction()

--- a/cmake/Platform/Other/ArduinoSDKSeeker.cmake
+++ b/cmake/Platform/Other/ArduinoSDKSeeker.cmake
@@ -86,7 +86,7 @@ function(find_arduino_sdk_root _return_var)
         set(${_return_var} "${unix_style_sdk_root_path}" PARENT_SCOPE)
     elseif (EXISTS "${ARDUINO_SDK_PATH}/hardware/tools/avr/etc/avrdude.conf")
         set(${_return_var} "${ARDUINO_SDK_PATH}/hardware/tools/avr" PARENT_SCOPE)
-    elseif (EXISTS "/etc/avrdude.conf")
+    elseif (EXISTS "/etc/avrdude.conf" OR EXISTS "/etc/avrdude/avrdude.conf")
         set(${_return_var} "/" PARENT_SCOPE)
     else ()
         string(CONCAT error_message

--- a/cmake/Platform/Other/ArduinoSDKSeeker.cmake
+++ b/cmake/Platform/Other/ArduinoSDKSeeker.cmake
@@ -40,6 +40,14 @@ function(find_arduino_sdk _return_var)
 
 endfunction()
 
+#=============================================================================#
+# Attempts to find the Arduino SDK's bin folder in the host system, searching at known locations.
+# Most installs will have it at SDK/hardware/tools/avr/bin but if nothing is there, it will 
+# attempt to find a folder in PATH containing avr-gcc, hoping that everything else will be there too
+# This is because a bunch of linux distros' package managers install the binaries into /usr/bin
+#       _return_var - Name of variable in parent-scope holding the return value.
+#       Returns - Path to the folder containing Arduino compiler binaries
+#=============================================================================#
 function(find_arduino_sdk_bin _return_var)
 
     if (DEFINED ENV{ARDUINO_SDK_BIN_PATH})
@@ -63,6 +71,14 @@ function(find_arduino_sdk_bin _return_var)
 
 endfunction()
 
+#=============================================================================#
+# Attempts to find the Arduino SDK's root folder in the host system, searching at known locations.
+# Most installs will have it at SDK/hardware/tools/avr/ but if nothing is there, it will 
+# attempt to find a folder containing etc/avrdude.conf, since a bunch of linux distros
+# put this into /etc rather than a subdirectory of the arduino SDK
+#       _return_var - Name of variable in parent-scope holding the return value.
+#       Returns - Path to the directory containing etc/avrdude.conf
+#=============================================================================#
 function(find_arduino_sdk_root _return_var)
 
     if (DEFINED ENV{ARDUINO_SDK_ROOT_PATH})

--- a/cmake/Platform/System/PlatformInitializer.cmake
+++ b/cmake/Platform/System/PlatformInitializer.cmake
@@ -37,7 +37,7 @@ function(initialize_arduino_platform)
 
     if (NOT DEFINED ARDUINO_CMAKE_PLATFORM_NAME OR NOT DEFINED ARDUINO_CMAKE_PLATFORM_PATH)
         if (USE_DEFAULT_PLATFORM_IF_NONE_EXISTING)
-            if (CMAKE_HOST_ARCHLINUX AND ${USE_ARCHLINUX_BUILTIN_SUPPORT})
+            if (IS_DIRECTORY "${ARDUINO_SDK_PATH}/hardware/archlinux-arduino")
                 set(ARDUINO_CMAKE_PLATFORM_NAME "archlinux-arduino" CACHE STRING "")
             else ()
                 set(ARDUINO_CMAKE_PLATFORM_NAME "arduino" CACHE STRING "")

--- a/cmake/Platform/System/SketchbookFinder.cmake
+++ b/cmake/Platform/System/SketchbookFinder.cmake
@@ -10,7 +10,11 @@ function(_get_user_preferences_file_path _return_var)
 
     if (${CMAKE_HOST_UNIX})
         if (${CMAKE_HOST_APPLE}) # Mac OS X
-            set(dir_path "$ENV{HOME}/Library/Processing/${preferences_file_name}")
+            if (EXISTS "$ENV{HOME}/Library/Arduino15/${preferences_file_name}")
+                set(dir_path "$ENV{HOME}/Library/Arduino15/${preferences_file_name}")
+            else ()
+                set(dir_path "$ENV{HOME}/Library/Processing/${preferences_file_name}")
+            endif ()
         else () # Linux
             if (EXISTS "$ENV{HOME}/.arduino15/${preferences_file_name}")
                 set(dir_path "$ENV{HOME}/.arduino15/${preferences_file_name}")

--- a/cmake/Platform/System/SketchbookFinder.cmake
+++ b/cmake/Platform/System/SketchbookFinder.cmake
@@ -12,7 +12,11 @@ function(_get_user_preferences_file_path _return_var)
         if (${CMAKE_HOST_APPLE}) # Mac OS X
             set(dir_path "$ENV{HOME}/Library/Processing/${preferences_file_name}")
         else () # Linux
-            set(dir_path "$ENV{HOME}/.processing/${preferences_file_name}")
+            if (EXISTS "$ENV{HOME}/.arduino15/${preferences_file_name}")
+                set(dir_path "$ENV{HOME}/.arduino15/${preferences_file_name}")
+            else ()
+                set(dir_path "$ENV{HOME}/.processing/${preferences_file_name}")
+            endif ()
         endif ()
     else () # Windows
         string(REPLACE "\\" "/" home_path $ENV{HOMEPATH})

--- a/cmake/Platform/Targets/ArduinoExampleTarget.cmake
+++ b/cmake/Platform/Targets/ArduinoExampleTarget.cmake
@@ -42,7 +42,15 @@ function(add_arduino_library_example _target_name _library_target_name _library_
         message(SEND_ERROR "Library target doesn't exist - It must be created first!")
     endif ()
 
-    find_arduino_library_example_sources("${ARDUINO_SDK_LIBRARIES_PATH}/${arduino_compliant_library_name}"
+    find_file(library_path
+            NAMES ${arduino_compliant_library_name}
+            PATHS ${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH} ${ARDUINO_SDK_LIBRARIES_PATH}
+            ${ARDUINO_CMAKE_SKETCHBOOK_PATH} ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}
+            PATH_SUFFIXES libraries dependencies
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH)
+
+    find_arduino_library_example_sources("${library_path}"
             ${arduino_compliant_example_name} example_sketches ${ARGN})
 
     add_arduino_executable(${_target_name})


### PR DESCRIPTION
Adds support for the Arduino IDE available from the [arduino](https://www.archlinux.org/packages/community/x86_64/arduino/) and [arduino-avr-core](https://www.archlinux.org/packages/community/any/arduino-avr-core/) arch linux repositories.  All examples now compile assuming you've installed the required Arduino libraries and set `AUTO_SET_SKETCHBOOK_PATH=ON`.

Hopefully fixes #53 (for Arch Linux, Ubuntu ships an ancient version 1.0.5 of the IDE, untested on Fedora)

AFAIK Fedora does something similar to Arch but I haven't tested that yet so if someone with Fedora could test that would be great

### Major differences between Arch install and the default distribution:
- Binaries are installed to `/usr/bin` instead of a subdirectory of `/usr/share/arduino`
- `avrdude.conf` is in `/etc` instead of a subdirectory of `/usr/share/arduino`
    - I didn't see any other use of `ARDUINO_SDK_ROOT_PATH` so I just set that to `/` if this is the case.  It didn't break my compiling of the examples, but if you do think that could break anything important please say so
- There is no `/usr/share/arduino/libraries`, all Arduino base libraries (like `Stepper`) are installed from the Arduino GUI package manager and get put in the user's sketchbook libraries folder.
    - If you need these, you'll need to enable `AUTO_SET_SKETCHBOOK_PATH=ON` or supply a sketchbook path

### Other Changes
- The Arduino IDE preferences file location is in `~/.arduino15` on linux and `~/Library/Arduino15` on mac.  Not sure what the old path was to, but I left it in as a fallback if the above paths don't exist
- Switched the `CMAKE_HOST_ARCHLINUX AND ${USE_ARCHLINUX_BUILTIN_SUPPORT}` check with a check for the existence of `${ARDUINO_SDK_PATH}/hardware/archlinux-arduino`.  The above check wasn't working for me, and if your arduino folder contains an `archlinux-arduino` subdirectory I would be surprised if that wasn't what you were supposed to use.
