### PR TITLE
Fix Fail to Build Examples if ARDUINO_SDK_PATH is not in Default Paths

### DIFF
--- a/cmake/Arduino-Toolchain.cmake
+++ b/cmake/Arduino-Toolchain.cmake
@@ -67,6 +67,7 @@ else ()
     # Set default path if none is set
     find_arduino_sdk(arduino_sdk_path)
     set(ARDUINO_SDK_PATH "${arduino_sdk_path}" CACHE PATH "Arduino SDK Path")
+    set(ENV{ARDUINO_SDK_PATH} "${ARDUINO_SDK_PATH}")
 endif ()
 
 _setup_sdk_internal_paths()


### PR DESCRIPTION
If the variable **ARDUINO_SDK_PATH** is given by the command line 
```bash
cmake ... -DARDUINO_SDK_PATH=<path-of-arduino-sdk>
```
rather than 
```bash
export ARDUINO_SDK_PATH=<path-of-arduino-sdk>
```
the examples are failed to build and output error in "ArduinoSDKSeeker.cmake" with unknown reason, though it's cached.