### PR TITLE
Fixed #98 by removing camelCasing of library names

### DIFF
--- a/cmake/Platform/Libraries/LibrariesFinder.cmake
+++ b/cmake/Platform/Libraries/LibrariesFinder.cmake
@@ -27,10 +27,6 @@ function(find_arduino_library _target_name _library_name)
 
     is_platform_library(${_library_name} is_plib) # Detect whether library is a platform library
 
-    if (NOT parsed_args_3RD_PARTY AND NOT is_plib)
-        convert_string_to_pascal_case(${_library_name} _library_name)
-    endif ()
-
     find_file(library_path
             NAMES "${_library_name}"
             PATHS ${ARDUINO_CMAKE_PLATFORM_LIBRARIES_PATH} ${ARDUINO_SDK_LIBRARIES_PATH}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_TOOLCHAIN_FILE ../cmake/Arduino-Toolchain.cmake)
 cmake_minimum_required(VERSION 3.8.2)
 
 project(Examples LANGUAGES C CXX ASM)

--- a/examples/arduino-library/CMakeLists.txt
+++ b/examples/arduino-library/CMakeLists.txt
@@ -7,7 +7,7 @@ arduino_cmake_project(Arduino_Library BOARD_NAME nano BOARD_CPU atmega328)
 add_arduino_executable(Arduino_Library test.cpp)
 
 # Find and link the Stepper library
-find_arduino_library(stepper_lib stePpEr) # Library name is case-insensitive to the user
+find_arduino_library(stepper_lib Stepper)
 link_arduino_library(Arduino_Library stepper_lib)
 
 # Find and link the Servo library - Custom implementation for many architectures, 

--- a/examples/platform-library/CMakeLists.txt
+++ b/examples/platform-library/CMakeLists.txt
@@ -11,3 +11,6 @@ link_arduino_library(Platform_Library wire)
 
 find_arduino_library(spi SPI)
 link_arduino_library(Platform_Library spi)
+
+find_arduino_library(sd SD)
+link_arduino_library(Platform_Library sd)

--- a/examples/platform-library/platformLibrary.cpp
+++ b/examples/platform-library/platformLibrary.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <Wire.h>
 #include <SPI.h>
+#include <SD.h>
 
 void setup()
 {


### PR DESCRIPTION
CamelCasing of library names caused issues with using the built-in SD library. I removed it, and fixed up the case where the stepper library example did not match that in the wiki docs. I also added an example with the SD library linked to act as a regression test. 

This change might break existing code that uses the CamelCasing feature.