### PR TITLE
Correct arduino compile command creation with unstripped parameters

### DIFF
--- a/cmake/Platform/Other/RecipeParser.cmake
+++ b/cmake/Platform/Other/RecipeParser.cmake
@@ -30,11 +30,12 @@ function(parse_compiler_recipe_flags _board_id _return_var)
     foreach (recipe_element ${original_list})
         _resolve_recipe_property("${recipe_element}" "${_board_id}" resolved_element)
         if (NOT "${resolved_element}" STREQUAL "") # Unresolved element, don't append
-            list(APPEND final_recipe "${resolved_element}")
+            string(STRIP ${resolved_element} element)
+            list(APPEND final_recipe "${element}")
         endif ()
     endforeach ()
 
-    set(${_return_var} "${final_recipe} " PARENT_SCOPE)
+    set(${_return_var} "${final_recipe}" PARENT_SCOPE)
 
 endfunction()
 


### PR DESCRIPTION
When configuring a project by cmake, some `flags.make` can contain unstripped newlines and extra spaces. This fix corrects it. Fix tested of Ubuntu 22.04.

Before:
```
CXX_FLAGS = -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto -mmcu=atmega168 -DF_CPU=16000000L -DARDUINO=108019+dfsg1-1 
"-DARDUINO_AVR_NANO "
```

After:
```
CXX_FLAGS = -c -g -Os -w -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto -mmcu=atmega168 -DF_CPU=16000000L -DARDUINO=108019+dfsg1-1 -DARDUINO_AVR_NANO
```